### PR TITLE
Add experimental widescreen support (mod-owned, 16:9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,21 @@ psxrecomp_add_game_runtime(psx-runtime
 # The game's own headers sit beside its sources.
 target_include_directories(psx-runtime PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
+# Project-owned mod catalog (this game's own manifests). Staged AFTER the
+# framework's builtin copy so copy_directory merges into the same tree
+# instead of being wiped by the framework's rm -rf. An always-run ALL target
+# (not POST_BUILD) so editing only a manifest.toml re-stages without needing
+# psx-runtime to relink.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded/packages")
+    add_custom_target(psx-stage-mods ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded"
+            "$<TARGET_FILE_DIR:psx-runtime>/mods"
+        COMMENT "Staging project-owned mod catalog"
+        VERBATIM)
+    add_dependencies(psx-stage-mods psx-runtime)
+endif()
+
 # Stage runtime configs next to the exe for direct build/ launches. Only copy
 # files that exist — never fail when game_options.toml is absent.
 #

--- a/game.toml
+++ b/game.toml
@@ -119,6 +119,15 @@ aspect_ratio = "4:3"
 # at all (at 1x a corrected vertex rounds back to the pixel it started on).
 supersampling = 2
 
+[widescreen]
+hud_sprt_squash = true
+auto_ui_squash  = true
+gte_game_mode   = true
+
+[widescreen.cull]
+auto_screen_x = true
+auto_backdrop = true
+
 [controller]
 default_mode = "digital"
 

--- a/mods/preloaded/packages/psx.enhancement.widescreen/1.0.0/manifest.toml
+++ b/mods/preloaded/packages/psx.enhancement.widescreen/1.0.0/manifest.toml
@@ -1,0 +1,22 @@
+format_version = 5
+id = "psx.enhancement.widescreen"
+version = "1.0.0"
+name = "Widescreen (experimental)"
+author = "yamyi"
+description = "Stretches to 16:9. Experimental."
+resolver = "declarative"
+save_compatibility = "shared"
+
+[[target]]
+game_id = "SLUS-01411"
+
+[[feature]]
+id = "widescreen"
+name = "Widescreen (experimental)"
+description = "Renders at 16:9 instead of native 4:3."
+group = "Quality of Life"
+default_enabled = false
+
+[[plugin]]
+feature = "widescreen"
+id = "psx.widescreen"

--- a/src/psx_ygo_widescreen.c
+++ b/src/psx_ygo_widescreen.c
@@ -1,0 +1,10 @@
+#include "mod_plugins.h"
+
+static void ygo_widescreen_activate(void) {
+    (void)psx_mod_set_fixed_display_aspect(16u, 9u);
+}
+
+PSX_MOD_CONSTRUCTOR(psx_register_ygo_widescreen_plugin) {
+    (void)psx_mod_register_activation_plugin(
+        "psx.widescreen", ygo_widescreen_activate);
+}


### PR DESCRIPTION
Adds a psx.enhancement.widescreen mod package (manifest + activation plugin
calling psx_mod_set_fixed_display_aspect) and the CMake staging rule for the
project's own mods/preloaded catalog into build/mods — nothing in this repo
needed that staging until now.

game.toml opts in via [widescreen]/[widescreen.cull] with gte_game_mode +
auto_screen_x/auto_backdrop, following the framework's WIDESCREEN.md pattern.

Tested and confirmed working in a live duel (screenshot below) — the duel
field renders genuinely wider, not just letterboxed.

Experimental, as the framework's own docs label this whole feature class.
Culling pop-in at the wide edges (a known issue even in the framework's
reference Tomba implementation) has NOT been checked here yet.

<img width="3837" height="2159" alt="image" src="https://github.com/user-attachments/assets/2271135b-5968-42a7-9ed8-4ade3c77b857" />
<img width="3837" height="2159" alt="image" src="https://github.com/user-attachments/assets/89b9a1a0-e395-4c6d-a33a-6237a6624328" />
