### PR TITLE
README: document the macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,17 @@ first is enough. Failing that it tries `-DYGOFM_DISC=<path>`, the disc this
 build directory already verified, then the one recorded beside the executable,
 and stops with a message rather than shipping a runtime with no art.
 
+### macOS
+
+Builds and runs natively on Apple Silicon with the commands above — no flags of
+its own. Prerequisites are the Xcode Command Line Tools plus
+`brew install cmake ninja pkg-config sdl3`.
+
+Build with `-j4` rather than the default on an 8 GB machine: the generated C
+includes shards of 400k+ lines, and four concurrent clang instances is where
+this stops being memory-bound. Vulkan compiles as a software stub unless the
+SDK is installed; the OpenGL renderer runs over Metal at full speed regardless.
+
 Add `-DPSX_DEBUG_TOOLS=ON` for a debug build with the TCP inspection server on
 `127.0.0.1:4370`.
 


### PR DESCRIPTION
Documents building this on macOS (Apple Silicon). README only — no code changes.

Nothing in this repository needed changing: its `CMakeLists.txt` has no platform conditionals at all, so once the framework builds, this does too. The fixes it depends on are in `psxrecomp` and are proposed separately in Unchiga/psxrecomp#1 — **this PR is only useful once that one lands**, since the submodule pin here is what carries them.

Verified on macOS 27 / M2 with Apple Clang 16 and Homebrew cmake, ninja and SDL3: clean configure and build of the game runtime, then 60 fps steady on the OpenGL renderer over Metal. A packaged setup zip also runs first-run generate → build → launch from a clean unzip.

The two notes in the section are the ones that cost me time and are not guessable: `-j4` rather than the default, because a 400k-line generated shard times four clang instances is where an 8 GB machine stops being memory-bound; and Vulkan compiling as a software stub without the SDK, which is easy to misread as something being broken.
