### PR TITLE
Add files via upload

### DIFF
--- a/src/psx_asset_manager.c
+++ b/src/psx_asset_manager.c
@@ -1,0 +1,1660 @@
+/* psx_asset_manager.c -- see psx_asset_manager.h.
+ *
+ * A reference window beside the game, same family as the Card/Dialogue/
+ * Fusion managers: browse what psx_wa_catalog.c's ONE TABLE knows how to
+ * export, compare the stock picture against whatever the active HD texture
+ * pack currently has for it, and upload a replacement without leaving the
+ * game or hand-typing a folder path.
+ *
+ * CATEGORIES AND ASSETS, NOT ONE FLAT LIST
+ * -----------------------------------------
+ * The catalog table already groups related art into "families" (a name_fmt
+ * like "cards/art/%03d"); this window turns that into the two-level browser
+ * the texture-pack folder itself already is. A category is everything in a
+ * name_fmt up to its LAST '/' ("cards/art", "ui/font", "backgrounds/comp");
+ * an asset is one instance of it ("001", "font", "01_layer1"). Two different
+ * table rows land in the same category when they share that prefix (the
+ * three duel_fields rows, the three background layers), which is exactly
+ * how the exporter already piles them into one folder.
+ *
+ * STOCK VS PACK, NOT STOCK VS "REPLACED"
+ * -----------------------------------------
+ * The stock side always decodes fresh from the disc via psx_wa_catalog_
+ * decode() -- the same call the exporter makes, so what this window shows
+ * is exactly what "Export stock textures" would write. The pack side reads
+ * whatever PNG currently sits at the path the exporter and the injector both
+ * use, at ITS OWN resolution (no forced resize): psx_ui_blit_scaled already
+ * scales an arbitrary source into a fixed box, so a 4x painted replacement
+ * shows the upscale it actually is instead of being squashed to stock size.
+ *
+ * MULTI-REGION UI ART HAS NO SINGLE "PACK FILE" TO SHOW
+ * -------------------------------------------------------
+ * Most families export as one flat PNG per asset and this window treats them
+ * that way: pick one, see two pictures, click Upload to replace the second.
+ * But a UI sheet drawn through more than one palette (psx_wa_catalog_ui(a) &&
+ * a->tint != 1 -- duel_labels, duel_panels, the monster-type icons, the menu labels,
+ * panels, dialog_frame, card_sleeves/canvas) exports as MANY small files
+ * named by a content hash, one per (rectangle, palette) pair the game was
+ * actually seen drawing -- see psx_texture_export.c's write_elements/
+ * write_screens. There is no single path to preview or replace for these;
+ * pretending otherwise would either show the wrong thing or invite an
+ * upload that the injector would never look for. This window instead lists
+ * whatever region files already exist for it and says so plainly.
+ *
+ * Same skeleton as psx_dialogue_manager.c: created on open and destroyed on
+ * close, the F10 menu's toolkit and palette, sizes in design units (one
+ * 480th of the window height), the software renderer on Windows and the
+ * accelerated one elsewhere with the game's GL context put back after every
+ * renderer call (PSX_TOOL_RENDERER overrides).
+ */
+
+#include "psx_asset_manager.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#define AM_MKDIR(p) _mkdir(p)
+#else
+#include <dirent.h>
+#include <unistd.h>
+#define AM_MKDIR(p) mkdir((p), 0755)
+#endif
+
+#include "psx_tool_window.h"
+#include "psx_sdl.h"
+
+#include "host_osd.h"
+#include "mod_plugins.h"
+#include "psx_game_hooks.h"
+#include "psx_ui_draw.h"
+#include "psx_ui_font.h"
+#include "psx_texture_export.h"
+#include "psx_wa_catalog.h"
+#include "texture_pack.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
+#define STBI_ONLY_PNG
+#define STBI_NO_STDIO
+#include "../psxrecomp/runtime/third_party/stb_image.h"
+
+/* --- look, matched to the other tool windows ------------------------------ */
+
+#define WIN_W  1400
+#define WIN_H   800
+
+#define COL_BG        0xFF0F1219u
+#define COL_BAR       0xFF141826u
+#define COL_PANEL     0xFF1E2233u
+#define COL_WELL      0xFF14171Fu   /* preview boxes: darker, so alpha reads */
+#define COL_TEXT      0xFFC9CFDDu
+#define COL_DIM       0xFF7C8598u
+#define COL_ACCENT    0xFF7FA6FFu
+#define COL_SEL_BG    0xFF2C3B60u
+#define COL_HOVER     0x14FFFFFFu
+#define COL_EDIT_BG   0xFF0E1119u
+#define COL_BTN       0xFF2A3147u
+#define COL_BTN_ON    0xFF3D5A9Cu
+#define COL_BTN_OFF   0xFF1C2030u   /* disabled (no folder chosen, etc.) */
+#define COL_TRACK     0x40FFFFFFu
+#define COL_THUMB     0xFF7C8598u
+#define COL_WARN      0xFFE8C36Au
+#define COL_HAVE      0xFF8BD48Bu   /* pack has this asset */
+#define COL_MISS      0xFF7C8598u   /* pack does not */
+
+#define U_BAR_H     26.0f
+#define U_GAP        6.0f
+#define U_PAD       10.0f
+#define U_ROW_H     16.0f
+#define U_HDR_H     16.0f
+#define U_BTN_H     17.0f
+#define U_FOOT_H    14.0f
+#define U_SB_W       4.0f
+#define U_R_PANEL    9.0f
+#define U_R_BOX      5.0f
+#define U_FS_TITLE  11.0f
+#define U_FS_BODY    9.5f
+#define U_FS_SMALL   8.5f
+#define U_CAT_W    150.0f
+#define U_ASSET_W  170.0f
+#define U_PREVIEW_H 260.0f
+
+#define S_ELLIP  "\xE2\x80\xA6"
+
+static SDL_Window   *s_win;
+static uint32_t     *s_px;
+static int           s_w, s_h;
+static int           s_dirty = 1;
+static PsxUiCanvas   s_cv;
+static float         s_u = 1.0f;
+
+static int px(float u) { return (int)(u * s_u + 0.5f); }
+static const PsxUiFace *face_title(void) { return psx_ui_font_face(U_FS_TITLE * s_u, PSX_UI_FONT_SEMIBOLD); }
+static const PsxUiFace *face_body(void)  { return psx_ui_font_face(U_FS_BODY * s_u, PSX_UI_FONT_REGULAR); }
+static const PsxUiFace *face_bold(void)  { return psx_ui_font_face(U_FS_BODY * s_u, PSX_UI_FONT_SEMIBOLD); }
+static const PsxUiFace *face_small(void) { return psx_ui_font_face(U_FS_SMALL * s_u, PSX_UI_FONT_REGULAR); }
+static int tw(const PsxUiFace *f, const char *s) { return f ? psx_ui_font_text_w(f, s) : 0; }
+
+typedef struct { int x, y, w, h; } Rect;
+static int in_rect(const Rect *r, int x, int y) { return x >= r->x && x < r->x + r->w && y >= r->y && y < r->y + r->h; }
+static void text_in(const Rect *r, int inset, const char *s, uint32_t col, const PsxUiFace *f)
+{
+    psx_ui_text_clip(&s_cv, r->x + inset, psx_ui_baseline_in(r->y, r->h, f), s, col, f, r->w - inset * 2);
+}
+static void text_centered(const Rect *r, const char *s, uint32_t col, const PsxUiFace *f)
+{
+    psx_ui_text(&s_cv, r->x + (r->w - tw(f, s)) / 2, psx_ui_baseline_in(r->y, r->h, f), s, col, f);
+}
+
+/* --- the catalog, flattened into categories and assets --------------------
+ *
+ * Built once and kept for the process's life: the table this reads
+ * (psx_wa_catalog_table) is a compile-time constant, so there is nothing to
+ * refresh it against. */
+#define CAT_MAX    64
+#define ASSET_MAX  3200   /* >= the ~2625 individual assets this title's
+                           * table currently expands to; see catalog_tick's
+                           * "registered" count for the live figure. */
+
+typedef struct {
+    char name[64];
+    int  count;             /* for the "(N)" badge only -- see AssetEntry.cat
+                             * for why membership is no longer a contiguous
+                             * range into s_assets[] */
+} Cat;
+
+typedef struct {
+    char name[48];          /* leaf: "001", "duel_labels", "01_layer1" */
+    int  cat;               /* which s_cats[] entry this belongs to. NOT
+                             * necessarily contiguous with its neighbours:
+                             * expand_interleaved_bg() runs its own pass AFTER
+                             * the main CAT_RULES loop has already interleaved
+                             * every other category, and can add more members
+                             * to a category that loop already created, with
+                             * everything from OTHER categories sitting
+                             * between them in s_assets[] by then. A category
+                             * used to be identified by a single (start,
+                             * count) range on the assumption that everything
+                             * in it landed back-to-back; that assumption
+                             * breaks the moment a second pass can add to an
+                             * already-populated category. Filtering by this
+                             * field instead of a range is what actually
+                             * answers "is this asset in category X", however
+                             * many separate passes contributed to it. */
+    int  row;               /* index into the psx_wa_catalog_table() array */
+    int  index;             /* 0-based within that row, for the decode calls */
+    int  multi_region;      /* 1: exports as many hash-named region files,
+                             * not one PNG -- see the file header. */
+} AssetEntry;
+
+static Cat        s_cats[CAT_MAX];
+static int        s_cat_n;
+static AssetEntry s_assets[ASSET_MAX];
+static int        s_asset_n;
+static int        s_catalog_built;
+
+/* "cards/art/%03d" -> cat "cards/art", leaf_fmt "%03d". Splits at the LAST
+ * '/' so a family with its own subdirectory ("ui/font/font") still nests
+ * the way its files actually sit on disk. */
+static void split_family(const char *name_fmt, char *cat, size_t catcap,
+                         char *leaf_fmt, size_t leafcap)
+{
+    const char *slash = strrchr(name_fmt, '/');
+    if (!slash) { snprintf(cat, catcap, "%s", ""); snprintf(leaf_fmt, leafcap, "%s", name_fmt); return; }
+    const size_t n = (size_t)(slash - name_fmt);
+    snprintf(cat, catcap, "%.*s", (int)(n < catcap - 1 ? n : catcap - 1), name_fmt);
+    snprintf(leaf_fmt, leafcap, "%s", slash + 1);
+}
+
+/* A leaf format may have no '%' at all (every count==1 asset without a
+ * numeric id, e.g. "duel_labels") -- snprintf with an int argument and no
+ * specifier to consume it is well-defined but warns on some compilers, so
+ * this only passes the id through when the format actually wants it. */
+static void format_leaf(const char *fmt, int id, char *out, size_t cap)
+{
+    if (strchr(fmt, '%')) snprintf(out, cap, fmt, id);
+    else snprintf(out, cap, "%s", fmt);
+}
+
+static int find_or_add_cat(const char *name)
+{
+    for (int i = 0; i < s_cat_n; i++)
+        if (!strcmp(s_cats[i].name, name)) return i;
+    if (s_cat_n >= CAT_MAX) return -1;
+    snprintf(s_cats[s_cat_n].name, sizeof s_cats[s_cat_n].name, "%s", name);
+    s_cats[s_cat_n].count = 0;
+    return s_cat_n++;
+}
+
+/* The path this asset's file actually lives at, root-relative and without
+ * extension -- "UI/Deck/panels" -- exactly what register_one() and
+ * export_one() (psx_wa_catalog.c / psx_texture_export.c) now both derive
+ * through psx_wa_catalog_display_path(), so this window's browsing tree and
+ * the on-disk folder tree are the SAME agreement instead of two hand-kept
+ * ones that used to intentionally differ (curated display vs. disc-family
+ * path). Falls back to the raw disc-family path for a row not yet listed in
+ * that table, matching the same fallback registration/export use.
+ *
+ */
+static void asset_rel_path(const AssetEntry *e, char *out, size_t cap)
+{
+    int rows = 0;
+    const PsxWaAsset *tbl = psx_wa_catalog_table(&rows);
+    if (e->row < 0 || e->row >= rows) { out[0] = 0; return; }
+    const PsxWaAsset *a = &tbl[e->row];
+    if (!psx_wa_catalog_display_path(a, e->index, out, (unsigned)cap))
+        snprintf(out, cap, a->name_fmt, a->first + e->index);
+}
+
+/* How many draws of a multi-region asset the running game has actually
+ * shown this session -- exactly the question "will Export stock textures
+ * write anything for this yet", since write_elements/write_screens
+ * (psx_texture_export.c) read from this same live table and write nothing
+ * when it is empty. 0 for anything that is not multi-region: a flat asset
+ * either has a disc palette or falls back to texpack_observed_clut() on its
+ * own, so "seen" is not the gate for it the way it is here.
+ *
+ * The name has to be reconstructed exactly as register_one()
+ * (psx_wa_catalog.c) built it -- asset_rel_path()'s curated path, now that
+ * registration itself derives its name the same way -- because that string,
+ * not a display label, is texpack's registration key. */
+static int asset_live_seen_count(const AssetEntry *e)
+{
+    if (!e->multi_region)
+        return 0;
+    char name[128];
+    asset_rel_path(e, name, sizeof name);
+    return texpack_clut_rect_count(name);
+}
+
+/* --- the curated browsing tree ---------------------------------------------
+ *
+ * The catalog's own family names are the right thing for a FILE PATH and the
+ * wrong thing for a MENU: "cards/titles" means nothing to a pack author, and
+ * a mechanically-derived tree scatters art someone thinks of as one screen
+ * (SAVE/LOAD/TRADE, BUILD DECK/OPTION/PASSWORD, the CAUTION box) across
+ * whatever family happened to catalogue it first. This table is hand-sorted
+ * by what a player recognises on screen instead.
+ *
+ * `name_fmt` matches a row's OWN name_fmt exactly -- the same string the
+ * ASSETS[] table in psx_wa_catalog.c uses -- so a row COULD be listed under
+ * more than one branch if that ever reads better than one home each (none
+ * currently are): each listing just re-decodes and re-paths the same row,
+ * never a second copy of the asset. `name_fmt` NULL means the branch exists
+ * with nothing catalogued under it
+ * yet -- shown with a (0) count rather than silently missing, so the menu
+ * this project is building toward is visible before every screen behind it
+ * has been individually catalogued (see the SU.MRG main-menu work). */
+typedef struct { const char *top, *sub, *name_fmt; } CatRule;
+static const CatRule CAT_RULES[] = {
+    { "UI", "fonts",      "ui/font/font" },
+    { "UI", "menu",       "ui/menu_labels_1" },
+    { "UI", "menu",       "ui/menu_labels_2" },
+    { "UI", "menu",       "ui/menu_labels_3" },
+    { "UI", "duel HUD",   "ui/duel_labels" },
+    { "UI", "duel HUD",   "ui/duel_panels" },
+    { "UI", "duel HUD",   "ui/duel_panels_lp" },
+    { "UI", "duel HUD",   "duel_fields/%d_top" },
+    { "UI", "duel HUD",   "duel_fields/%d_bottom" },
+    { "UI", "duel HUD",   "duel_fields/%d_middle" },
+    { "UI", "duel HUD",   "ui/duel_hand/canvas" },
+    { "UI", "icons",      "ui/icons/monster_types" },
+    { "UI", "icons",      "ui/icons/attributes" },
+    { "UI", "Logo",       "ui/logo/front" },
+    { "UI", "Logo",       "ui/logo/copyright" },
+    { "UI", "Logo",       "ui/logo/back" },
+    { "UI", "Logo",       "ui/logo/konami" },
+    { "UI", "Dialogue",   "ui/dialog_frame" },
+    /* Option / Trade: each a specific screen the SU.MRG main-menu
+     * investigation is still splitting out of the shared menu-label pages
+     * above (see ui/menu_labels_1..3's own header comment in
+     * psx_wa_catalog.c) -- placeholders until that finishes rather than an
+     * incorrect guess at which pixels belong to which screen. Deck's own
+     * furniture (CHEST/ORDER/DECK) IS already catalogued, at ui/panels. */
+    { "UI", "Deck",       "ui/panels" },
+    { "UI", "Option",     NULL },
+    { "UI", "Trade",      NULL },
+    /* Library's own card-grid/digit sheet -- a WA_MRG.MRG package entirely
+     * separate from the SU.MRG menu-label pages above. Its OTHER sheet, the
+     * card-viewer frame, is not a second row here: it is the exact same
+     * bytes as ui/card_sleeves/canvas (see the provenance comment on this
+     * row in psx_wa_catalog.c), so it already appears under Card assets. */
+    { "UI", "Library",    "ui/library/grid" },
+    /* Password's own screen furniture -- a WA_MRG.MRG package entirely
+     * separate from the SU.MRG menu-label pages above, so it did not need
+     * to wait on that investigation; found via memories-decomp (see the
+     * provenance comment on these rows in psx_wa_catalog.c). */
+    { "UI", "Password",   "ui/password/card" },
+    { "UI", "Password",   "ui/password/cursor" },
+    { "UI", "Password",   "ui/password/frame" },
+    { "UI", "Results",    "ui/results/labels" },
+    { "UI", "Results",    "ui/results/banner" },
+    { "UI", "Name Entry", "ui/name_entry/background" },
+    { "UI", "Name Entry", "ui/name_entry/frame" },
+
+    { "Card assets", "card artworks",   "cards/art/%03d" },
+    { "Card assets", "card thumbnails", "cards/mini/%03d" },
+    { "Card assets", "card Titles",     "cards/titles/%03d" },
+    { "Card assets", "card Frames",     "ui/card_sleeves/canvas" },
+    { "Card assets", "card Frames",     "ui/card_sleeves/duel_sprites" },
+    { "Card assets", "card Frames",     "ui/card_sleeves/text_placeholders" },
+
+    { "Campaign", "Static Backgrounds",     "backgrounds/static/%02d" },
+    /* NOT listed here: the comp/mov layers interleave (00_layer1, 00_layer2,
+     * 00_layer3, 01_layer1, ...) rather than running all of one layer before
+     * the next, which a flat name_fmt-per-rule rule can't express -- see
+     * expand_interleaved_bg, called separately in build_catalog(). */
+    { "Campaign", "characters",             "campaign_characters/%03d" },
+    { "Campaign", "cutscene portraits",     "dialog_thumbnails/thumb_%03d" },
+
+    { "Free duel", "portraits",  "free_duel/portrait_%03d" },
+    { "Free duel", "background", "free_duel/background" },
+    /* No free-duel-specific UI art is catalogued separately yet -- the
+     * screen reuses the shared UI sheet above (UI > menu, UI > duel HUD). */
+    { "Free duel", "UI",         NULL },
+};
+#define CAT_RULE_N ((int)(sizeof CAT_RULES / sizeof CAT_RULES[0]))
+
+static int find_row_by_name_fmt(const PsxWaAsset *tbl, int rows, const char *name_fmt)
+{
+    for (int t = 0; t < rows; t++)
+        if (!strcmp(tbl[t].name_fmt, name_fmt)) return t;
+    return -1;
+}
+
+/* Appends one (row, index) instance to category ci, formatting its leaf name
+ * from that row's own name_fmt. Shared by the plain per-rule expansion below
+ * and by expand_interleaved_bg's per-index interleave. */
+static void append_asset(int ci, const PsxWaAsset *tbl, int t, int index)
+{
+    if (ci < 0 || s_asset_n >= ASSET_MAX) return;
+    const PsxWaAsset *a = &tbl[t];
+    char cat_unused[64], leaf_fmt[48];
+    split_family(a->name_fmt, cat_unused, sizeof cat_unused, leaf_fmt, sizeof leaf_fmt);
+    AssetEntry *e = &s_assets[s_asset_n];
+    format_leaf(leaf_fmt, a->first + index, e->name, sizeof e->name);
+    e->cat = ci; e->row = t; e->index = index;
+    /* tint == 0 is the "genuinely drawn through more than one palette"
+     * case export_one() (psx_texture_export.c) treats as multi-region --
+     * this must agree with that exact condition or an asset can export as
+     * one flat file while this window still shows it as region fragments
+     * (or vice versa). tint == -1 (dialog_frame, panels, back, copyright)
+     * has one real fixed palette and is a flat file; tint == 1 is the
+     * always-tinted mask case, also flat. */
+    e->multi_region = psx_wa_catalog_ui(a) && a->tint == 0;
+    s_cats[ci].count++;
+    s_asset_n++;
+}
+
+/* backgrounds/comp and backgrounds/mov each store their three layers as
+ * separate table rows (a layer is its own palette, its own bpp even), but a
+ * pack author thinks of them as one background with three parts -- 00_layer1,
+ * 00_layer2, 00_layer3, then 01's three, not all 42 of layer1 before layer2
+ * starts. Interleaving by index is what a plain per-rule CAT_RULES entry
+ * cannot express, so this runs it directly. */
+static void expand_interleaved_bg(const PsxWaAsset *tbl, int rows,
+                                  const char *top, const char *sub,
+                                  const char *fmt1, const char *fmt2, const char *fmt3)
+{
+    char label[80];
+    snprintf(label, sizeof label, "%s / %s", top, sub);
+    const int ci = find_or_add_cat(label);
+    const int t1 = find_row_by_name_fmt(tbl, rows, fmt1);
+    const int t2 = find_row_by_name_fmt(tbl, rows, fmt2);
+    const int t3 = find_row_by_name_fmt(tbl, rows, fmt3);
+    if (ci < 0 || t1 < 0 || t2 < 0 || t3 < 0) return;
+    const int n = tbl[t1].count;
+    for (int i = 0; i < n && s_asset_n < ASSET_MAX; i++) {
+        append_asset(ci, tbl, t1, i);
+        append_asset(ci, tbl, t2, i);
+        append_asset(ci, tbl, t3, i);
+    }
+}
+
+static void build_catalog(void)
+{
+    if (s_catalog_built) return;
+    s_catalog_built = 1;
+    int rows = 0;
+    const PsxWaAsset *tbl = psx_wa_catalog_table(&rows);
+    for (int r = 0; r < CAT_RULE_N; r++) {
+        const CatRule *rule = &CAT_RULES[r];
+        char label[80];
+        snprintf(label, sizeof label, "%s / %s", rule->top, rule->sub);
+        const int ci = find_or_add_cat(label);
+        if (ci < 0 || !rule->name_fmt) continue;   /* NULL: placeholder branch */
+        const int t = find_row_by_name_fmt(tbl, rows, rule->name_fmt);
+        if (t < 0) continue;                       /* should not happen; stay safe */
+        for (int i = 0; i < tbl[t].count && s_asset_n < ASSET_MAX; i++)
+            append_asset(ci, tbl, t, i);
+    }
+    expand_interleaved_bg(tbl, rows, "Campaign", "Compounded Backgrounds",
+                         "backgrounds/comp/%02d_layer1", "backgrounds/comp/%02d_layer2", "backgrounds/comp/%02d_layer3");
+    expand_interleaved_bg(tbl, rows, "Campaign", "cutscenes Backgrounds",
+                         "backgrounds/mov/%02d_layer1", "backgrounds/mov/%02d_layer2", "backgrounds/mov/%02d_layer3");
+}
+
+/* --- state ----------------------------------------------------------------- */
+
+static int  s_open_req;
+static int  s_cat_sel = -1, s_asset_sel = -1;
+static int  s_cat_scroll, s_asset_scroll;
+static int  s_cat_hover = -1, s_asset_hover = -1;
+static char s_search[48];
+static int  s_caret_on = 1;
+static char s_msg[256];
+static Uint32 s_msg_until;
+
+static char s_pack_root[1024];     /* "" until chosen or an active pack exists */
+
+/* the two preview images for the current selection */
+#define PIXELS_MAX (256 * 768)     /* the largest whole image the table holds */
+static uint32_t s_stock_argb[PIXELS_MAX];
+static int      s_stock_ok, s_stock_w, s_stock_h;
+static const uint32_t *stock_ptr(void) { return s_stock_argb; }
+static uint32_t *s_pack_argb;       /* malloc'd: an uploaded pack file may be
+                                     * far larger than PIXELS_MAX (a 4x paint) */
+static int      s_pack_ok, s_pack_w, s_pack_h;
+static int      s_preview_asset = -1;   /* which s_assets[] index they are for */
+static char     s_preview_root[1024];   /* which pack root they were read from */
+
+/* multi-region: filenames already exported for the current selection.
+ *
+ * Was 64. A long session on a busy multi-context sheet (duel_labels: every
+ * distinct rect+palette combination actually drawn gets its own file) grows
+ * past that easily -- caught duel_labels at 71 files, with readdir()'s
+ * unsorted order putting one of them at position 67. scan_region_files()
+ * below stops the moment it hits the cap, so anything past it is silently
+ * missing from the Pack preview -- the file is fine on disk, it was just
+ * never looked at. Raised well past the one count observed rather than to
+ * it exactly, since the next long session hits whatever number is chosen
+ * eventually too. 4096 entries costs 4096*64 = 256 KB static, trivial. */
+#define REGION_FILES_MAX 4096
+static char s_region_files[REGION_FILES_MAX][64];
+static int  s_region_n;
+
+/* multi-region: the region files re-assembled into one picture, the same
+ * way write_screens() (psx_texture_export.c) lays them out for a human to
+ * look at -- every region filename already carries its own destination
+ * rect ("x_y_WxH@hash.png", see write_elements), so this just blits each
+ * decoded region into a canvas sized to the asset's own declared w/h at
+ * that rect instead of leaving the pack side of the window blank. Not a
+ * new export format: still reads exactly the files write_elements wrote. */
+static uint32_t *s_pack_region_argb;
+static int       s_pack_region_ok, s_pack_region_w, s_pack_region_h;
+
+enum { BTN_FOLDER = 0, BTN_UPLOAD, BTN_OPEN_FOLDER, BTN_EXPORT, BTN_EXPORT_ALL, BTN_COUNT };
+static const char *const BTN_LABEL[BTN_COUNT] = {
+    "Choose pack folder" S_ELLIP, "Upload" S_ELLIP, "Open folder",
+    "Export" S_ELLIP, "Export all" S_ELLIP
+};
+
+/* the file/folder dialog's answer, consumed on the emulation thread */
+static char s_pick_path[1200];
+static int  s_pick_kind;   /* 1 folder chosen, 2 file to upload, 3 export-one
+                             * destination, 4 export-all destination */
+
+/* Export All walks s_assets[] a handful at a time from tick() (see the
+ * background exporter's own "a few per frame" reasoning in
+ * psx_texture_export.c's header -- doing ~2700 disc decodes in one button
+ * click would freeze the window for the same reason doing all of them in one
+ * frame would freeze the game) rather than in one shot, so the window keeps
+ * redrawing and the footer message can show live progress. */
+static char s_export_all_root[1200];
+static int  s_export_all_active;
+static int  s_export_all_idx;
+static int  s_export_all_written;
+static int  s_export_all_failed;
+#define EXPORT_ALL_PER_TICK 8
+
+typedef struct {
+    Rect bar, btn[BTN_COUNT], search;
+    Rect cats, assets, detail;
+    Rect prev_stock, prev_pack;
+    Rect region_list;
+    int  row_h;
+} Layout;
+static Layout s_L;
+
+static void say(const char *m)
+{
+    snprintf(s_msg, sizeof s_msg, "%s", m);
+    s_msg_until = SDL_GetTicks() + 6000u;
+    s_dirty = 1;
+}
+
+/* --- reading pictures ------------------------------------------------------ */
+
+static unsigned char *read_file(const char *path, long *size)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0 || sz > (64L << 20)) { fclose(f); return NULL; }
+    unsigned char *buf = (unsigned char *)malloc((size_t)sz);
+    if (!buf || fread(buf, 1, (size_t)sz, f) != (size_t)sz) { free(buf); fclose(f); return NULL; }
+    fclose(f);
+    *size = sz;
+    return buf;
+}
+
+static void mkdir_p(char *path)
+{
+    for (char *p = path + 1; *p; p++) {
+        if (*p != '/') continue;
+        *p = '\0';
+        AM_MKDIR(path);
+        *p = '/';
+    }
+    AM_MKDIR(path);
+}
+
+/* <root>/<rel>.png, the same path the exporter writes and the injector reads
+ * -- the one fixed point both this window and the running game agree on.
+ * `rel` is asset_rel_path()'s result: the curated path when this asset has
+ * one, the raw disc-family path otherwise -- either way, exactly what
+ * register_one()/export_one() derived the same name from. */
+static void asset_path(const char *root, const char *rel,
+                       char *out, size_t cap)
+{
+    snprintf(out, cap, "%s/%s.png", root, rel);
+}
+
+/* <root>/<rel>/ -- where a multi-region asset's per-rectangle files land
+ * (see psx_texture_export.c's write_elements/write_screens). */
+static void asset_dir(const char *root, const char *rel,
+                      char *out, size_t cap)
+{
+    snprintf(out, cap, "%s/%s", root, rel);
+}
+
+/* Native resolution, no forced resize: psx_ui_blit_scaled fits whatever this
+ * returns into the preview box, so a painted 4x replacement shows the
+ * upscale it actually is. */
+static int load_png_native(const char *path, uint32_t **out_argb, int *w, int *h)
+{
+    long sz;
+    unsigned char *file = read_file(path, &sz);
+    if (!file) return 0;
+    int comp;
+    unsigned char *img = stbi_load_from_memory(file, (int)sz, w, h, &comp, 4);
+    free(file);
+    if (!img) return 0;
+    const size_t n = (size_t)(*w) * (size_t)(*h);
+    uint32_t *argb = (uint32_t *)malloc(n * 4u);
+    if (!argb) { stbi_image_free(img); return 0; }
+    for (size_t i = 0; i < n; i++) {
+        const unsigned char *p = img + i * 4u;
+        argb[i] = ((uint32_t)p[3] << 24) | ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | p[2];
+    }
+    stbi_image_free(img);
+    *out_argb = argb;
+    return 1;
+}
+
+/* Filenames already exported for a multi-region asset -- no path, just what
+ * a listing of its subfolder finds, so the window can say "3 regions
+ * exported" without pretending there is one file to preview or replace.
+ *
+ * Skips names starting with '_' -- "_reference.png" (psx_texture_export.c)
+ * is deliberately named so the RUNTIME's exact-match replacement lookup
+ * never picks it up; this scan didn't know that convention and counted it
+ * as a captured region anyway, so an asset with zero real captures but a
+ * written reference showed "1 region file exported" with nothing to show
+ * for it (compose_region_files()'s sscanf silently skips the unparseable
+ * name, so the count and the composed preview disagreed -- caught on
+ * duel_fields/0_top, whose Pack panel was blank under that misleading
+ * count). Any future underscore-prefixed helper file gets the same pass. */
+static void scan_region_files(const char *dir)
+{
+    s_region_n = 0;
+#if defined(_WIN32)
+    char glob[1200];
+    snprintf(glob, sizeof glob, "%s\\*.png", dir);
+    WIN32_FIND_DATAA fd;
+    HANDLE h = FindFirstFileA(glob, &fd);
+    if (h == INVALID_HANDLE_VALUE) return;
+    do {
+        if (s_region_n >= REGION_FILES_MAX) break;
+        if (fd.cFileName[0] == '_') continue;
+        snprintf(s_region_files[s_region_n++], sizeof s_region_files[0], "%s", fd.cFileName);
+    } while (FindNextFileA(h, &fd));
+    FindClose(h);
+#else
+    DIR *dp = opendir(dir);
+    if (!dp) return;
+    struct dirent *de;
+    while ((de = readdir(dp)) != NULL && s_region_n < REGION_FILES_MAX) {
+        if (de->d_name[0] == '_') continue;
+        const char *ext = strrchr(de->d_name, '.');
+        if (!ext || strcmp(ext, ".png") != 0) continue;
+        snprintf(s_region_files[s_region_n++], sizeof s_region_files[0], "%s", de->d_name);
+    }
+    closedir(dp);
+#endif
+}
+
+/* Reassembles this multi-region asset's exported files into one picture at
+ * canvas_w x canvas_h -- the asset's own declared display size, the same
+ * canvas write_screens() (psx_texture_export.c) lays these exact rectangles
+ * into for its own "screens" reference output. Each region filename
+ * already carries its destination rect ("x_y_WxH@hash.png", see
+ * write_elements), so no new bookkeeping is needed to place it.
+ *
+ * Two regions can legitimately share one rectangle -- the same wordmark
+ * exported once per palette it is actually drawn through (a Konami-style
+ * black/white wash) -- and here scan order decides which is on top. That is
+ * fine for a review picture; it is not the injector's own per-draw CLUT
+ * match and is not meant to stand in for it. */
+static void compose_region_files(const char *dir, int canvas_w, int canvas_h)
+{
+    free(s_pack_region_argb); s_pack_region_argb = NULL;
+    s_pack_region_ok = 0; s_pack_region_w = s_pack_region_h = 0;
+    if (canvas_w <= 0 || canvas_h <= 0 || (size_t)canvas_w * (size_t)canvas_h > PIXELS_MAX)
+        return;
+    uint32_t *canvas = (uint32_t *)calloc((size_t)canvas_w * (size_t)canvas_h, 4u);
+    if (!canvas) return;
+
+    int placed = 0;
+    for (int i = 0; i < s_region_n; i++) {
+        int x0, y0, w, h;
+        if (sscanf(s_region_files[i], "%d_%d_%dx%d@", &x0, &y0, &w, &h) != 4)
+            continue;
+        char path[1300];
+        snprintf(path, sizeof path, "%s/%s", dir, s_region_files[i]);
+        uint32_t *argb = NULL; int rw, rh;
+        if (!load_png_native(path, &argb, &rw, &rh)) continue;
+        for (int y = 0; y < rh; y++) {
+            const int cy = y0 + y;
+            if (cy < 0 || cy >= canvas_h) continue;
+            for (int x = 0; x < rw; x++) {
+                const int cx = x0 + x;
+                if (cx < 0 || cx >= canvas_w) continue;
+                canvas[(size_t)cy * canvas_w + cx] = argb[(size_t)y * rw + x];
+            }
+        }
+        free(argb);
+        placed++;
+    }
+
+    if (placed) {
+        s_pack_region_argb = canvas;
+        s_pack_region_w = canvas_w; s_pack_region_h = canvas_h;
+        s_pack_region_ok = 1;
+    } else {
+        free(canvas);
+    }
+}
+
+static void free_pack_preview(void)
+{
+    free(s_pack_argb); s_pack_argb = NULL;
+    s_pack_ok = 0; s_pack_w = s_pack_h = 0;
+    free(s_pack_region_argb); s_pack_region_argb = NULL;
+    s_pack_region_ok = 0; s_pack_region_w = s_pack_region_h = 0;
+}
+
+/* Re-decode the stock side and re-read the pack side for whichever asset is
+ * selected. Cheap enough to call on every selection change and every folder
+ * change: the stock decode is one disc-format image, and the pack read is
+ * one small PNG file -- neither is a per-frame cost, this only runs on
+ * clicks. */
+static void refresh_preview(void)
+{
+    if (s_asset_sel == s_preview_asset && !strcmp(s_pack_root, s_preview_root))
+        return;
+    s_preview_asset = s_asset_sel;
+    snprintf(s_preview_root, sizeof s_preview_root, "%s", s_pack_root);
+    free_pack_preview();
+    s_stock_ok = 0;
+    s_region_n = 0;
+    if (s_asset_sel < 0) return;
+
+    const AssetEntry *e = &s_assets[s_asset_sel];
+    int rows = 0;
+    const PsxWaAsset *tbl = psx_wa_catalog_table(&rows);
+    const PsxWaAsset *a = &tbl[e->row];
+    psx_wa_catalog_disp_size(a, e->index, &s_stock_w, &s_stock_h);
+    if ((size_t)s_stock_w * (size_t)s_stock_h <= PIXELS_MAX) {
+        static uint8_t rgba[PIXELS_MAX * 4];
+        if (psx_wa_catalog_decode(a, e->index, rgba)) {
+            const size_t n = (size_t)s_stock_w * (size_t)s_stock_h;
+            for (size_t i = 0; i < n; i++) {
+                const uint8_t *p = rgba + i * 4u;
+                s_stock_argb[i] = ((uint32_t)p[3] << 24) | ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | p[2];
+            }
+            s_stock_ok = 1;
+        }
+    }
+
+    if (!s_pack_root[0]) return;
+    char rel[128]; asset_rel_path(e, rel, sizeof rel);
+    if (e->multi_region) {
+        char dir[1200];
+        asset_dir(s_pack_root, rel, dir, sizeof dir);
+        scan_region_files(dir);
+        /* Same canvas the stock decode above just used -- the exported
+         * regions are destination rects within that same declared size. */
+        compose_region_files(dir, s_stock_w, s_stock_h);
+    } else {
+        char path[1200];
+        asset_path(s_pack_root, rel, path, sizeof path);
+        s_pack_ok = load_png_native(path, &s_pack_argb, &s_pack_w, &s_pack_h);
+    }
+}
+
+/* --- layout ---------------------------------------------------------------- */
+
+static void layout_compute(void)
+{
+    Layout *L = &s_L;
+    const int gap = px(U_GAP), pad = px(U_PAD);
+    L->row_h = px(U_ROW_H);
+    L->bar = (Rect){ 0, 0, s_w, px(U_BAR_H) };
+
+    int x = s_w - pad;
+    const PsxUiFace *fb = face_body();
+    for (int b = BTN_COUNT - 1; b >= 0; b--) {
+        const int w = tw(fb, BTN_LABEL[b]) + px(16.0f);
+        x -= w;
+        L->btn[b] = (Rect){ x, (L->bar.h - px(U_BTN_H)) / 2, w, px(U_BTN_H) };
+        x -= gap;
+    }
+    const int sw = px(160.0f);
+    L->search = (Rect){ x - sw - gap, (L->bar.h - px(U_BTN_H)) / 2, sw, px(U_BTN_H) };
+
+    const int body_y = L->bar.h + gap, body_h = s_h - body_y - pad;
+    const int cat_w = px(U_CAT_W), asset_w = px(U_ASSET_W);
+    L->cats   = (Rect){ pad, body_y, cat_w, body_h };
+    L->assets = (Rect){ L->cats.x + cat_w + gap, body_y, asset_w, body_h };
+    L->detail = (Rect){ L->assets.x + asset_w + gap, body_y,
+                        s_w - pad - (L->assets.x + asset_w + gap), body_h };
+
+    const int prev_h = px(U_PREVIEW_H);
+    const int half = (L->detail.w - gap) / 2;
+    L->prev_stock = (Rect){ L->detail.x, L->detail.y + px(U_HDR_H), half, prev_h };
+    L->prev_pack  = (Rect){ L->detail.x + half + gap, L->detail.y + px(U_HDR_H), half, prev_h };
+    L->region_list = (Rect){ L->detail.x, L->prev_stock.y + prev_h + gap + px(U_HDR_H),
+                             L->detail.w, L->detail.h - (px(U_HDR_H) + prev_h + gap + px(U_HDR_H)) - px(U_FOOT_H) - gap };
+}
+
+static int cat_rows(void) { const int n = s_L.cats.h / (s_L.row_h > 0 ? s_L.row_h : 1); return n > 0 ? n : 1; }
+static int asset_rows(void) { const int n = s_L.assets.h / (s_L.row_h > 0 ? s_L.row_h : 1); return n > 0 ? n : 1; }
+
+static int cat_at(int x, int y)
+{
+    if (!in_rect(&s_L.cats, x, y)) return -1;
+    const int hdr = px(U_HDR_H);
+    if (y < s_L.cats.y + hdr) return -1;
+    const int r = s_cat_scroll + (y - (s_L.cats.y + hdr)) / s_L.row_h;
+    return r < s_cat_n ? r : -1;
+}
+
+static int filtered_asset_row(int i)
+{
+    /* Maps a VISIBLE row to an asset index within the selected category,
+     * honouring the search box. Scans every asset checking e->cat rather
+     * than a (start, count) range -- see AssetEntry.cat for why a range
+     * stopped being able to answer "is this in category X" once a second
+     * pass (expand_interleaved_bg) could add to a category an earlier pass
+     * already created. Linear, but ASSET_MAX tops out in the low thousands
+     * and this only runs on input, not per frame. */
+    if (s_cat_sel < 0) return -1;
+    int seen = 0;
+    for (int k = 0; k < s_asset_n; k++) {
+        const AssetEntry *e = &s_assets[k];
+        if (e->cat != s_cat_sel) continue;
+        if (s_search[0]) {
+            char lo[48], needle[48], *p;
+            snprintf(lo, sizeof lo, "%s", e->name);
+            snprintf(needle, sizeof needle, "%s", s_search);
+            for (p = lo; *p; p++) if (*p >= 'A' && *p <= 'Z') *p += 32;
+            for (p = needle; *p; p++) if (*p >= 'A' && *p <= 'Z') *p += 32;
+            if (!strstr(lo, needle)) continue;
+        }
+        if (seen == i) return k;
+        seen++;
+    }
+    return -1;
+}
+
+static int filtered_asset_count(void)
+{
+    int n = 0;
+    while (filtered_asset_row(n) >= 0) n++;
+    return n;
+}
+
+static int asset_at(int x, int y)
+{
+    if (!in_rect(&s_L.assets, x, y)) return -1;
+    const int hdr = px(U_HDR_H);
+    if (y < s_L.assets.y + hdr) return -1;
+    const int r = s_asset_scroll + (y - (s_L.assets.y + hdr)) / s_L.row_h;
+    return filtered_asset_row(r);
+}
+
+static int button_at(int x, int y)
+{
+    for (int b = 0; b < BTN_COUNT; b++) if (in_rect(&s_L.btn[b], x, y)) return b;
+    return -1;
+}
+
+static void set_cat_scroll(int v)
+{
+    const int max = s_cat_n - cat_rows();
+    if (v > max) v = max > 0 ? max : 0;
+    if (v < 0) v = 0;
+    if (v != s_cat_scroll) { s_cat_scroll = v; s_dirty = 1; }
+}
+static void set_asset_scroll(int v)
+{
+    const int max = filtered_asset_count() - asset_rows();
+    if (v > max) v = max > 0 ? max : 0;
+    if (v < 0) v = 0;
+    if (v != s_asset_scroll) { s_asset_scroll = v; s_dirty = 1; }
+}
+
+/* --- drawing ---------------------------------------------------------------- */
+
+static void draw_button(const Rect *r, const char *label, int hover, int enabled)
+{
+    psx_ui_round_rect(&s_cv, r->x, r->y, r->w, r->h, U_R_BOX * s_u,
+                      !enabled ? COL_BTN_OFF : (hover ? COL_BTN_ON : COL_BTN));
+    text_centered(r, label, enabled ? COL_TEXT : COL_DIM, face_body());
+}
+
+/* set by on_event/tick before draw(), read by draw_bar's hover highlight --
+ * a plain global instead of threading one more parameter through, since
+ * nothing else needs it. */
+static int s_hover_btn_cache = -1;
+
+static void draw_bar(void)
+{
+    const Layout *L = &s_L;
+    psx_ui_fill(&s_cv, L->bar.x, L->bar.y, L->bar.w, L->bar.h, COL_BAR);
+    char title[256];
+    snprintf(title, sizeof title, "Textures   %s", s_pack_root[0] ? s_pack_root : "no pack folder chosen yet");
+    Rect t = { px(U_PAD), L->bar.y, L->search.x - px(U_PAD) - px(U_GAP), L->bar.h };
+    text_in(&t, 0, title, s_pack_root[0] ? COL_TEXT : COL_WARN, face_title());
+
+    psx_ui_round_rect(&s_cv, L->search.x, L->search.y, L->search.w, L->search.h, U_R_BOX * s_u, COL_EDIT_BG);
+    if (s_search[0]) {
+        char shown[64]; snprintf(shown, sizeof shown, "%s%s", s_search, s_caret_on ? "|" : "");
+        text_in(&L->search, px(5.0f), shown, COL_TEXT, face_body());
+    } else text_in(&L->search, px(5.0f), "Filter assets", COL_DIM, face_body());
+
+    const int has_asset = s_asset_sel >= 0 && !s_assets[s_asset_sel].multi_region;
+    for (int b = 0; b < BTN_COUNT; b++) {
+        int enabled;
+        if (b == BTN_FOLDER) enabled = 1;
+        else if (b == BTN_UPLOAD) enabled = s_pack_root[0] && has_asset;
+        else if (b == BTN_OPEN_FOLDER) enabled = s_pack_root[0] && s_asset_sel >= 0;
+        else if (b == BTN_EXPORT) enabled = s_asset_sel >= 0 && !s_export_all_active;
+        else /* BTN_EXPORT_ALL */ enabled = !s_export_all_active;
+        draw_button(&L->btn[b], BTN_LABEL[b], b == s_hover_btn_cache && enabled, enabled);
+    }
+}
+
+static void draw_cats(void)
+{
+    const Layout *L = &s_L;
+    psx_ui_round_rect(&s_cv, L->cats.x, L->cats.y, L->cats.w, L->cats.h, U_R_PANEL * s_u, COL_PANEL);
+    Rect hdr = { L->cats.x, L->cats.y, L->cats.w, px(U_HDR_H) };
+    text_in(&hdr, px(6.0f), "Categories", COL_DIM, face_small());
+    const int rows_y = L->cats.y + px(U_HDR_H);
+    const int nrows = cat_rows();
+    for (int i = 0; i < nrows && s_cat_scroll + i < s_cat_n; i++) {
+        const int row = s_cat_scroll + i;
+        const int y = rows_y + i * L->row_h;
+        if (row == s_cat_sel) psx_ui_round_rect(&s_cv, L->cats.x, y, L->cats.w, L->row_h, U_R_BOX * s_u, COL_SEL_BG);
+        else if (row == s_cat_hover) psx_ui_round_rect(&s_cv, L->cats.x, y, L->cats.w, L->row_h, U_R_BOX * s_u, COL_HOVER);
+        Rect r = { L->cats.x, y, L->cats.w, L->row_h };
+        char label[96];
+        snprintf(label, sizeof label, "%s (%d)", s_cats[row].name, s_cats[row].count);
+        text_in(&r, px(6.0f), label, row == s_cat_sel ? COL_TEXT : COL_DIM, face_body());
+    }
+}
+
+static void draw_assets(void)
+{
+    const Layout *L = &s_L;
+    psx_ui_round_rect(&s_cv, L->assets.x, L->assets.y, L->assets.w, L->assets.h, U_R_PANEL * s_u, COL_PANEL);
+    Rect hdr = { L->assets.x, L->assets.y, L->assets.w, px(U_HDR_H) };
+    if (s_cat_sel < 0) { text_in(&hdr, px(6.0f), "Pick a category", COL_DIM, face_small()); return; }
+    char label[64];
+    snprintf(label, sizeof label, "%s", s_cats[s_cat_sel].name);
+    text_in(&hdr, px(6.0f), label, COL_DIM, face_small());
+    const int rows_y = L->assets.y + px(U_HDR_H);
+    const int nrows = asset_rows();
+    for (int i = 0; i < nrows; i++) {
+        const int ai = filtered_asset_row(s_asset_scroll + i);
+        if (ai < 0) break;
+        const int y = rows_y + i * L->row_h;
+        if (ai == s_asset_sel) psx_ui_round_rect(&s_cv, L->assets.x, y, L->assets.w, L->row_h, U_R_BOX * s_u, COL_SEL_BG);
+        else if (s_asset_scroll + i == s_asset_hover) psx_ui_round_rect(&s_cv, L->assets.x, y, L->assets.w, L->row_h, U_R_BOX * s_u, COL_HOVER);
+        Rect r = { L->assets.x, y, L->assets.w - px(14.0f), L->row_h };
+        text_in(&r, px(6.0f), s_assets[ai].name, ai == s_asset_sel ? COL_TEXT : COL_TEXT, face_body());
+        /* a small dot: does the pack already have this one? Cheap enough to
+         * stat() per visible row (a couple dozen), not per asset. Three
+         * states for a multi-region asset, since "the pack has it" and "the
+         * exporter has anything to write" are different questions for one of
+         * these -- see asset_live_seen_count(): amber means Export stock
+         * textures will actually produce something right now, grey-hollow
+         * means the screen that draws it still needs a visit first. */
+        char path[1200], rel[128];
+        struct stat st;
+        int have;
+        asset_rel_path(&s_assets[ai], rel, sizeof rel);
+        if (s_assets[ai].multi_region) {
+            char dir[1200];
+            asset_dir(s_pack_root[0] ? s_pack_root : ".", rel, dir, sizeof dir);
+            have = s_pack_root[0] && stat(dir, &st) == 0;
+        } else {
+            asset_path(s_pack_root[0] ? s_pack_root : ".", rel, path, sizeof path);
+            have = s_pack_root[0] && stat(path, &st) == 0;
+        }
+        uint32_t dot_col = have ? COL_HAVE : COL_MISS;
+        int ready = have;
+        if (!have && s_assets[ai].multi_region && asset_live_seen_count(&s_assets[ai]) > 0)
+            { dot_col = COL_WARN; ready = 1; }
+        Rect dot = { L->assets.x + L->assets.w - px(12.0f), y, px(8.0f), L->row_h };
+        text_centered(&dot, ready ? "\xE2\x97\x8F" : "\xE2\x97\x8B", dot_col, face_small());
+    }
+    if (filtered_asset_count() > nrows) {
+        Rect sb = { L->assets.x + L->assets.w - px(U_SB_W), rows_y, px(U_SB_W), L->assets.h - px(U_HDR_H) };
+        psx_ui_round_rect(&s_cv, sb.x, sb.y, sb.w, sb.h, U_SB_W * s_u, COL_TRACK);
+        const int total = filtered_asset_count();
+        const int th = sb.h * nrows / total;
+        const int ty = sb.y + (sb.h - th) * s_asset_scroll / (total - nrows);
+        psx_ui_round_rect(&s_cv, sb.x, ty, sb.w, th > px(8.0f) ? th : px(8.0f), U_SB_W * s_u, COL_THUMB);
+    }
+}
+
+/* Fit src into box, preserving aspect ratio, centred -- a 320x160 background
+ * and a 12x16 icon both land readably instead of one being squashed and the
+ * other lost in a corner. */
+static void fit_rect(const Rect *box, int sw, int sh, Rect *out)
+{
+    if (sw <= 0 || sh <= 0) { *out = *box; return; }
+    const float sx = (float)box->w / (float)sw, sy = (float)box->h / (float)sh;
+    const float s = sx < sy ? sx : sy;
+    out->w = (int)(sw * s); out->h = (int)(sh * s);
+    out->x = box->x + (box->w - out->w) / 2;
+    out->y = box->y + (box->h - out->h) / 2;
+}
+
+/* Empty-state message in a caller-chosen colour -- used to make "ready to
+ * export" (COL_WARN) visually distinct from "nothing here yet" (COL_DIM)
+ * for a multi-region asset's pack side, see draw_detail(). */
+static void draw_preview_box_col(const Rect *box, const char *caption,
+                                 int ok, const uint32_t *argb, int sw, int sh,
+                                 const char *empty_msg, uint32_t empty_col)
+{
+    psx_ui_round_rect(&s_cv, box->x, box->y - px(U_HDR_H), box->w, box->h + px(U_HDR_H), U_R_BOX * s_u, COL_WELL);
+    Rect cap = { box->x, box->y - px(U_HDR_H), box->w, px(U_HDR_H) };
+    text_in(&cap, px(4.0f), caption, COL_DIM, face_small());
+    if (ok && argb) {
+        Rect fit; fit_rect(box, sw, sh, &fit);
+        psx_ui_blit_scaled(&s_cv, fit.x, fit.y, fit.w, fit.h, U_R_BOX * s_u, argb, sw, sh);
+        char dims[32]; snprintf(dims, sizeof dims, "%dx%d", sw, sh);
+        Rect d = { box->x + px(4.0f), box->y + box->h - px(12.0f), box->w - px(8.0f), px(11.0f) };
+        text_in(&d, 0, dims, COL_DIM, face_small());
+    } else {
+        Rect m = { box->x, box->y + box->h / 2 - px(6.0f), box->w, px(12.0f) };
+        text_centered(&m, empty_msg, empty_col, face_small());
+    }
+}
+
+static void draw_preview_box(const Rect *box, const char *caption,
+                             int ok, const uint32_t *argb, int sw, int sh,
+                             const char *empty_msg)
+{
+    draw_preview_box_col(box, caption, ok, argb, sw, sh, empty_msg, COL_DIM);
+}
+
+static void draw_detail(void)
+{
+    const Layout *L = &s_L;
+    psx_ui_round_rect(&s_cv, L->detail.x, L->detail.y, L->detail.w, L->detail.h, U_R_PANEL * s_u, COL_PANEL);
+    if (s_asset_sel < 0) {
+        Rect t = { L->detail.x, L->detail.y, L->detail.w, px(U_HDR_H) };
+        text_in(&t, px(6.0f), "Select an asset to compare it against the pack", COL_DIM, face_body());
+        return;
+    }
+    const AssetEntry *e = &s_assets[s_asset_sel];
+    Rect t = { L->detail.x, L->detail.y, L->detail.w, px(U_HDR_H) };
+    char head[96];
+    snprintf(head, sizeof head, "%s / %s%s", s_cats[s_cat_sel].name, e->name,
+            e->multi_region ? "  (multi-region UI art)" : "");
+    text_in(&t, px(6.0f), head, COL_TEXT, face_bold());
+
+    draw_preview_box(&L->prev_stock, "Stock (from the disc)",
+                     s_stock_ok, stock_ptr(), s_stock_w, s_stock_h,
+                     "could not decode");
+
+    if (e->multi_region) {
+        /* "Has the game drawn this yet" and "does the pack have files for
+         * it" are different questions for a multi-region asset -- the first
+         * is what Export stock textures actually reads from (see
+         * asset_live_seen_count()), the second is what a previous export
+         * left on disk. Both get their own message so the empty case says
+         * which one to go do, instead of one flat "nothing here". */
+        const int seen = asset_live_seen_count(e);
+        char msg[80];
+        uint32_t msg_col = COL_DIM;
+        if (s_region_n > 0) {
+            snprintf(msg, sizeof msg, "%d region file%s exported", s_region_n, s_region_n == 1 ? "" : "s");
+        } else if (!s_pack_root[0]) {
+            snprintf(msg, sizeof msg, "choose a pack folder first");
+        } else if (seen > 0) {
+            snprintf(msg, sizeof msg, "%d draw%s seen \xE2\x80\x94 ready: Mods > Export stock textures",
+                    seen, seen == 1 ? "" : "s");
+            msg_col = COL_WARN;
+        } else {
+            snprintf(msg, sizeof msg, "not seen yet \xE2\x80\x94 visit the screen that draws this");
+        }
+        /* Composited from the same per-region files below, laid out at
+         * their own destination rects -- how the asset actually looks
+         * assembled, not a promise that it is one file underneath. */
+        draw_preview_box_col(&L->prev_pack, "Pack (assembled from regions)",
+                        s_pack_region_ok, s_pack_region_argb, s_pack_region_w, s_pack_region_h,
+                        msg, msg_col);
+        Rect rh = { L->region_list.x, L->region_list.y - px(U_HDR_H), L->region_list.w, px(U_HDR_H) };
+        text_in(&rh, px(6.0f), "This asset is drawn through more than one palette, so the game and the "
+                              "exporter capture it as several small files, assembled above for review -- "
+                              "editing means replacing the region file(s) below, not one whole picture. "
+                              "Visit the screen that draws it, then Mods > Export stock textures; the "
+                              "files appear once it has been.", COL_DIM, face_small());
+        for (int i = 0; i < s_region_n; i++) {
+            Rect r = { L->region_list.x, L->region_list.y + i * L->row_h, L->region_list.w, L->row_h };
+            if (r.y + L->row_h > L->region_list.y + L->region_list.h) break;
+            text_in(&r, px(6.0f), s_region_files[i], COL_DIM, face_small());
+        }
+    } else {
+        draw_preview_box(&L->prev_pack, "Pack (replaces this)", s_pack_ok, s_pack_argb, s_pack_w, s_pack_h,
+                        s_pack_root[0] ? "not in the pack yet -- Upload one" : "choose a pack folder first");
+    }
+}
+
+static void draw_footer(void)
+{
+    const Layout *L = &s_L;
+    const char *m = s_msg[0] ? s_msg :
+        "Click a category, then an asset. Green \xE2\x97\x8F: the pack has it. Amber \xE2\x97\x8F: seen in-game, ready to export. Upload replaces the file directly.";
+    Rect r = { px(U_PAD), s_h - px(U_FOOT_H), s_w - px(U_PAD) * 2, px(U_FOOT_H) };
+    text_in(&r, 0, m, s_msg[0] ? COL_WARN : COL_DIM, face_small());
+}
+
+static void draw(void)
+{
+    s_cv.px = s_px; s_cv.w = s_w; s_cv.h = s_h;
+    layout_compute();
+    psx_ui_fill(&s_cv, 0, 0, s_w, s_h, COL_BG);
+    draw_bar();
+    draw_cats();
+    draw_assets();
+    draw_detail();
+    draw_footer();
+}
+
+/* --- actions ---------------------------------------------------------------- */
+
+#if defined(PSX_SDL3)
+static void SDLCALL pick_cb(void *userdata, const char *const *filelist, int filter)
+{
+    (void)filter;
+    if (!filelist || !filelist[0]) return;
+    snprintf(s_pick_path, sizeof s_pick_path, "%s", filelist[0]);
+    s_pick_kind = (int)(intptr_t)userdata;
+}
+#endif
+
+static void do_choose_folder(void)
+{
+#if defined(PSX_SDL3)
+    const char *start = s_pack_root[0] ? s_pack_root : psx_mod_player_data_dir();
+    SDL_ShowOpenFolderDialog(pick_cb, (void *)(intptr_t)1, s_win, start, false);
+#else
+    say("No folder dialog in this build: the active texture pack is used automatically");
+#endif
+}
+
+/* Writes an uploaded replacement into the pack, correcting it first when the
+ * target asset is TINTED (currently just the font -- see psx_wa_catalog_tinted
+ * and export_one()'s own tinted branch in psx_texture_export.c). Tinted art is
+ * a white mask on transparency that the shader recolours per draw; an
+ * upscaler that flattens the file onto a background destroys that alpha and
+ * produces something that looks right in a viewer but draws as solid dark
+ * blocks in-game. This is exactly the transform tools/font_mask.py applies by
+ * hand (see its own header for the mechanism) -- luminance becomes coverage,
+ * RGB is forced white, and an input that still carries real (non-opaque)
+ * alpha at a pixel is left alone there, so running this on an already-correct
+ * mask is a no-op. Every OTHER asset is written byte-for-byte as uploaded:
+ * for ordinary art a dark pixel means dark, not absent, and "correcting" it
+ * the same way would delete every shadow in it -- font_mask.py's own SCOPE
+ * note says exactly this. Returns 1 on success. */
+/* 1: written. 0: could not read/decode the source file. -1: decoded (or read)
+ * fine but the write into the pack folder failed. Kept distinct so the
+ * caller can report the same two messages this always gave, tinted or not. */
+static int save_upload(const char *src_path, const char *dst_path, int tinted)
+{
+    if (!tinted) {
+        long sz;
+        unsigned char *bytes = read_file(src_path, &sz);
+        if (!bytes) return 0;
+        FILE *f = fopen(dst_path, "wb");
+        const int ok = f && fwrite(bytes, 1, (size_t)sz, f) == (size_t)sz;
+        if (f) fclose(f);
+        free(bytes);
+        return ok ? 1 : -1;
+    }
+
+    long sz;
+    unsigned char *file = read_file(src_path, &sz);
+    if (!file) return 0;
+    int w, h, comp;
+    unsigned char *img = stbi_load_from_memory(file, (int)sz, &w, &h, &comp, 4);
+    free(file);
+    if (!img) return 0;
+
+    const size_t n = (size_t)w * (size_t)h;
+    uint8_t *mask = (uint8_t *)malloc(n * 4u);
+    if (!mask) { stbi_image_free(img); return -1; }
+    for (size_t i = 0; i < n; i++) {
+        const unsigned char *p = img + i * 4u;
+        const int lum = ((int)p[0] * 299 + (int)p[1] * 587 + (int)p[2] * 114) / 1000;
+        const int a = p[3];
+        mask[i * 4 + 0] = mask[i * 4 + 1] = mask[i * 4 + 2] = 255;
+        mask[i * 4 + 3] = (uint8_t)(a == 255 ? lum : (a < lum ? a : lum));
+    }
+    stbi_image_free(img);
+    const int ok = psx_texture_export_write_png(dst_path, mask, w, h);
+    free(mask);
+    return ok ? 1 : -1;
+}
+
+static void do_upload(void)
+{
+    if (s_asset_sel < 0 || s_assets[s_asset_sel].multi_region || !s_pack_root[0]) return;
+#if defined(PSX_SDL3)
+    static const SDL_DialogFileFilter filters[] = { { "PNG images", "png" } };
+    SDL_ShowOpenFileDialog(pick_cb, (void *)(intptr_t)2, s_win, filters, 1, psx_mod_player_data_dir(), false);
+#else
+    say("No file dialog in this build: copy the PNG into the pack folder by hand");
+#endif
+}
+
+/* Opens the REAL on-disk folder for the selected ASSET, not the curated
+ * category it is browsed under -- a category like "UI > duel HUD" can span
+ * more than one real directory (ui/, duel_fields/), so "the category's
+ * folder" has no single answer once the browsing tree stopped mirroring the
+ * disk layout. The asset's own folder always does. */
+static void do_open_folder(void)
+{
+    if (s_asset_sel < 0 || !s_pack_root[0]) return;
+    char rel[128], dir[1200];
+    asset_rel_path(&s_assets[s_asset_sel], rel, sizeof rel);
+    char *slash = strrchr(rel, '/');
+    if (slash) *slash = 0;   /* rel's own containing folder, not its leaf */
+    snprintf(dir, sizeof dir, "%s/%s", s_pack_root, rel);
+    mkdir_p(dir);
+#if defined(PSX_SDL3)
+    SDL_OpenURL(dir);
+#endif
+}
+
+/* Exports ONE catalog-driven asset to dest_root via psx_texture_export_one()
+ * (psx_texture_export.c) -- the SAME logic the old automatic "Mods > Export
+ * stock textures" walker used, just called on demand with a caller-chosen
+ * destination instead of a background frame-hook always targeting the
+ * active pack. That single function already handles every asset shape
+ * correctly (multi-region live-captured elements for genuinely multi-palette
+ * UI sheets, tinted white masks, plain disc decode, reference-PNG
+ * fallbacks) -- reimplementing any of that here would either drift from it
+ * or leave multi-region sheets (duel_labels and the like) permanently
+ * unexportable, since this window has no other path to their live-captured
+ * per-region data. */
+static int export_stock_png(const AssetEntry *e, const char *dest_root)
+{
+    int rows = 0;
+    const PsxWaAsset *tbl = psx_wa_catalog_table(&rows);
+    if (e->row < 0 || e->row >= rows) return 0;
+    return psx_texture_export_one(&tbl[e->row], e->index, dest_root);
+}
+
+static void do_export_one(void)
+{
+    if (s_asset_sel < 0 || s_export_all_active) return;
+#if defined(PSX_SDL3)
+    SDL_ShowOpenFolderDialog(pick_cb, (void *)(intptr_t)3, s_win, psx_mod_player_data_dir(), false);
+#else
+    say("No folder dialog in this build");
+#endif
+}
+
+static void do_export_all(void)
+{
+    if (s_export_all_active) return;
+#if defined(PSX_SDL3)
+    SDL_ShowOpenFolderDialog(pick_cb, (void *)(intptr_t)4, s_win, psx_mod_player_data_dir(), false);
+#else
+    say("No folder dialog in this build");
+#endif
+}
+
+static void run_button(int b)
+{
+    if (b == BTN_FOLDER) do_choose_folder();
+    else if (b == BTN_UPLOAD) do_upload();
+    else if (b == BTN_OPEN_FOLDER) do_open_folder();
+    else if (b == BTN_EXPORT) do_export_one();
+    else if (b == BTN_EXPORT_ALL) do_export_all();
+}
+
+static void select_cat(int i)
+{
+    if (i < 0 || i >= s_cat_n || i == s_cat_sel) return;
+    s_cat_sel = i; s_asset_sel = -1; s_asset_scroll = 0; s_search[0] = 0;
+    s_dirty = 1;
+}
+static void select_asset(int i)
+{
+    if (i < 0) return;
+    s_asset_sel = i;
+    refresh_preview();
+    s_dirty = 1;
+}
+
+static void click(int x, int y)
+{
+    const int b = button_at(x, y);
+    if (b >= 0) { run_button(b); return; }
+    const int c = cat_at(x, y);
+    if (c >= 0) { select_cat(c); return; }
+    const int a = asset_at(x, y);
+    if (a >= 0) { select_asset(a); return; }
+}
+
+/* --- window lifecycle, event pump: identical shape to the sibling tool
+ * windows (psx_dialogue_manager.c, psx_card_manager.c) -- see there for why
+ * each piece is the way it is (renderer fallback, GL context save/restore,
+ * canvas-size-follows-window). Not re-explained here. */
+
+static SDL_Renderer *s_ren;
+static SDL_Texture  *s_tex;
+static SDL_Window   *s_gl_win;
+static SDL_GLContext s_gl_ctx;
+static int           s_ren_software;
+static int           s_present_fail;
+
+static void gl_capture(void) { s_gl_win = SDL_GL_GetCurrentWindow(); s_gl_ctx = SDL_GL_GetCurrentContext(); }
+static void gl_restore(void)
+{
+    if (s_ren_software) return;
+    if (s_gl_ctx && s_gl_win && SDL_GL_GetCurrentContext() != s_gl_ctx) SDL_GL_MakeCurrent(s_gl_win, s_gl_ctx);
+}
+
+static int ensure_canvas(int w, int h)
+{
+    if (w == s_w && h == s_h && s_px && s_tex) return 1;
+    if (s_tex) { SDL_DestroyTexture(s_tex); s_tex = NULL; }
+    free(s_px);
+    s_px = (uint32_t *)malloc((size_t)w * (size_t)h * 4u);
+    if (!s_px) { s_w = s_h = 0; gl_restore(); return 0; }
+    s_tex = SDL_CreateTexture(s_ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, w, h);
+    gl_restore();
+    if (!s_tex) { free(s_px); s_px = NULL; s_w = s_h = 0; return 0; }
+    s_w = w; s_h = h;
+    s_u = (float)h / 480.0f;
+    if (s_u < 1.0f) s_u = 1.0f;
+    if (s_u > 8.0f) s_u = 8.0f;
+    s_dirty = 1;
+    return 1;
+}
+
+static void present_canvas(void)
+{
+    if (!s_ren || !s_tex) return;
+    const int ok = psx_tool_present(s_ren, s_tex, s_px, s_w, s_h, "Textures");
+    gl_restore();
+    if (ok) { s_present_fail = 0; return; }
+    if (++s_present_fail < 3) { s_dirty = 1; return; }
+    psx_tool_log("Textures: switching to the %s renderer after %d failed presents", s_ren_software ? "accelerated" : "software", s_present_fail);
+    gl_capture();
+    if (s_tex) { SDL_DestroyTexture(s_tex); s_tex = NULL; }
+    SDL_DestroyRenderer(s_ren);
+    s_ren = psx_tool_renderer_create(s_win, "Textures", s_ren_software ? 1 : 0, &s_ren_software);
+    gl_restore();
+    s_present_fail = 0;
+    if (!s_ren) { psx_asset_manager_close(); return; }
+    const int w = s_w, h = s_h; s_w = s_h = 0;
+    if (!ensure_canvas(w, h)) { psx_asset_manager_close(); return; }
+    s_dirty = 1;
+}
+
+void psx_asset_manager_open(void)
+{
+    if (s_win) { SDL_RaiseWindow(s_win); return; }
+    build_catalog();
+    /* Always the active pack's own folder -- never left empty waiting for a
+     * pack to happen to already be active, which is what let this window and
+     * the folder card art/CPU portraits actually read from drift apart. Also
+     * arms it as the runtime's ACTUAL active pack (texture_pack.c no longer
+     * does this by itself at boot -- see discover_packs()'s comment on why),
+     * so opening this window is what turns raw VRAM replacement on for it,
+     * not something every launch pays a directory scan for regardless of
+     * whether this window is ever opened. */
+    if (!s_pack_root[0]) {
+        texpack_active_dir(s_pack_root, (unsigned)sizeof s_pack_root);
+        texpack_set_active_dir(s_pack_root);
+    }
+    s_win = psx_fm_editor_acquire(PSX_FM_PAGE_TEXTURES, WIN_W, WIN_H);
+    if (!s_win) { host_osd_push("Textures: no window", 2000); return; }
+    gl_capture();
+    s_ren = psx_tool_renderer_create(s_win, "Textures", -1, &s_ren_software);
+    gl_restore();
+    s_present_fail = 0;
+    if (!s_ren) {
+        psx_fm_editor_release(PSX_FM_PAGE_TEXTURES); s_win = NULL;
+        host_osd_push("Textures: no renderer", 2000);
+        return;
+    }
+    if (!ensure_canvas(WIN_W, WIN_H)) { psx_asset_manager_close(); return; }
+    layout_compute();
+    SDL_StartTextInput(s_win);
+}
+
+void psx_asset_manager_close(void)
+{
+    const int preserve = psx_fm_editor_is_switching();
+    if (s_tex) { SDL_DestroyTexture(s_tex); s_tex = NULL; }
+    if (s_ren) { SDL_DestroyRenderer(s_ren); s_ren = NULL; }
+    if (s_win) { psx_fm_editor_release(PSX_FM_PAGE_TEXTURES); s_win = NULL; }
+    gl_restore();
+    s_ren_software = 0;
+    free(s_px); s_px = NULL;
+    s_w = s_h = 0;
+    if (preserve) return;
+    s_cat_hover = s_asset_hover = -1;
+    free_pack_preview();
+    s_preview_asset = -1;
+}
+
+int psx_asset_manager_is_open(void) { return s_win != NULL; }
+
+static int on_event(const void *evp)
+{
+    const SDL_Event *raw = (const SDL_Event *)evp;
+    SDL_Event adjusted;
+    if (!s_win) return 0;
+    if (psx_fm_editor_filter_event(PSX_FM_PAGE_TEXTURES, raw, &adjusted)) return 1;
+    const SDL_Event *ev = &adjusted;
+    const Uint32 id = SDL_GetWindowID(s_win);
+    switch (ev->type) {
+    case SDL_MOUSEBUTTONDOWN: {
+        if (ev->button.windowID != id) return 0;
+        if (ev->button.button != SDL_BUTTON_LEFT) return 1;
+        layout_compute();
+        click((int)ev->button.x, (int)ev->button.y);
+        return 1;
+    }
+    case SDL_MOUSEBUTTONUP:
+        return ev->button.windowID == id;
+    case SDL_MOUSEMOTION: {
+        if (ev->motion.windowID != id) return 0;
+        layout_compute();
+        const int c = cat_at((int)ev->motion.x, (int)ev->motion.y);
+        const int a = asset_at((int)ev->motion.x, (int)ev->motion.y);
+        const int b = button_at((int)ev->motion.x, (int)ev->motion.y);
+        /* s_asset_hover, like draw_assets()'s hover check, is a filtered
+         * VISIBLE-ROW rank (what filtered_asset_row's own index means),
+         * not an absolute s_assets[] index -- so translate asset_at()'s
+         * absolute index back to that rank the same way filtered_asset_row
+         * produces it, rather than assuming a category is a contiguous
+         * range (it isn't; see AssetEntry.cat). */
+        int ar = -1;
+        if (a >= 0 && s_cat_sel >= 0) {
+            for (int k = 0; ; k++) {
+                const int idx = filtered_asset_row(k);
+                if (idx < 0) break;
+                if (idx == a) { ar = k; break; }
+            }
+        }
+        if (c != s_cat_hover || ar != s_asset_hover || b != s_hover_btn_cache) {
+            s_cat_hover = c; s_asset_hover = ar; s_hover_btn_cache = b; s_dirty = 1;
+        }
+        return 1;
+    }
+    case SDL_MOUSEWHEEL: {
+        if (ev->wheel.windowID != id) return 0;
+        int mx, my;
+#if defined(PSX_SDL3)
+        mx = (int)ev->wheel.mouse_x; my = (int)ev->wheel.mouse_y;
+#else
+        SDL_GetMouseState(&mx, &my);
+#endif
+        layout_compute();
+        if (in_rect(&s_L.cats, mx, my)) set_cat_scroll(s_cat_scroll + (ev->wheel.y > 0 ? -3 : 3));
+        else set_asset_scroll(s_asset_scroll + (ev->wheel.y > 0 ? -3 : 3));
+        return 1;
+    }
+    case SDL_KEYDOWN: {
+        if (ev->key.windowID != id) return 0;
+#if defined(PSX_SDL3)
+        const int key = (int)ev->key.key;
+#else
+        const int key = (int)ev->key.keysym.sym;
+#endif
+        if (key == SDLK_ESCAPE) {
+            if (s_search[0]) { s_search[0] = 0; s_asset_scroll = 0; }
+            else psx_asset_manager_close();
+        } else if (key == SDLK_BACKSPACE) {
+            const size_t n = strlen(s_search);
+            if (n) { s_search[n - 1] = 0; s_asset_scroll = 0; }
+        } else if (key == SDLK_UP) set_asset_scroll(s_asset_scroll - 1);
+        else if (key == SDLK_DOWN) set_asset_scroll(s_asset_scroll + 1);
+        s_dirty = 1;
+        return 1;
+    }
+    case SDL_TEXTINPUT:
+        if (ev->text.windowID != id) return 0;
+        for (const char *p = ev->text.text; *p; p++) {
+            if ((unsigned char)*p >= 32u && (unsigned char)*p < 127u) {
+                const size_t n = strlen(s_search);
+                if (n + 1 < sizeof s_search) { s_search[n] = *p; s_search[n + 1] = 0; }
+            }
+        }
+        s_asset_scroll = 0;
+        s_dirty = 1;
+        return 1;
+    case SDL_WINDOWEVENT_CLOSE:
+        if (ev->window.windowID != id) return 0;
+        psx_asset_manager_close();
+        return 1;
+    case SDL_WINDOWEVENT_EXPOSED:
+    case SDL_WINDOWEVENT_RESIZED:
+    case SDL_WINDOWEVENT_SIZE_CHANGED:
+        if (ev->window.windowID != id) return 0;
+        s_dirty = 1;
+        return 1;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static void tick(void)
+{
+    const int req = s_open_req;
+    if (req) {
+        s_open_req = 0;
+        if (req > 0) psx_asset_manager_open(); else psx_asset_manager_close();
+    }
+    if (s_pick_kind) {
+        const int kind = s_pick_kind; s_pick_kind = 0;
+        if (kind == 1) {
+            snprintf(s_pack_root, sizeof s_pack_root, "%s", s_pick_path);
+            /* Make it the ACTIVE pack, not just what this window happens to
+             * be looking at: the raw VRAM injector, the exporter, card art
+             * and CPU portraits all resolve "the pack folder" through this
+             * same call, so picking a folder here is what makes it real
+             * everywhere else too. */
+            texpack_set_active_dir(s_pack_root);
+            char msg[1200]; snprintf(msg, sizeof msg, "Pack folder: %s", s_pack_root);
+            say(msg);
+        } else if (kind == 2 && s_asset_sel >= 0 && !s_assets[s_asset_sel].multi_region) {
+            AssetEntry *e = &s_assets[s_asset_sel];
+            int rows = 0;
+            const PsxWaAsset *tbl = psx_wa_catalog_table(&rows);
+            const int tinted = psx_wa_catalog_tinted(&tbl[e->row]);
+
+            char path[1200], rel[128];
+            asset_rel_path(e, rel, sizeof rel);
+            asset_path(s_pack_root, rel, path, sizeof path);
+            char dir[1200]; snprintf(dir, sizeof dir, "%s", path);
+            char *slash = strrchr(dir, '/'); if (slash) *slash = 0;
+            mkdir_p(dir);
+
+            const int r = save_upload(s_pick_path, path, tinted);
+            if (r > 0) {
+                char msg[1300];
+                snprintf(msg, sizeof msg, "Saved to %s%s", path,
+                         tinted ? " (alpha rebuilt from luminance)" : "");
+                say(msg);
+                s_preview_asset = -1;   /* force a reread */
+                refresh_preview();
+            } else if (r < 0) {
+                say("Could not write into the pack folder");
+            } else {
+                say(tinted ? "Could not read that file as an image"
+                           : "Could not read that file");
+            }
+        } else if (kind == 3 && s_asset_sel >= 0) {
+            char path[1200], rel[128];
+            asset_rel_path(&s_assets[s_asset_sel], rel, sizeof rel);
+            asset_path(s_pick_path, rel, path, sizeof path);
+            char msg[1300];
+            if (export_stock_png(&s_assets[s_asset_sel], s_pick_path))
+                snprintf(msg, sizeof msg, "Exported stock image to %s", path);
+            else
+                snprintf(msg, sizeof msg, "Could not export -- no disc image for this asset");
+            say(msg);
+        } else if (kind == 4) {
+            snprintf(s_export_all_root, sizeof s_export_all_root, "%s", s_pick_path);
+            s_export_all_active = 1;
+            s_export_all_idx = 0;
+            s_export_all_written = 0;
+            s_export_all_failed = 0;
+        }
+    }
+    /* Export All: a handful of stock decodes per tick, not all ~2700 in one
+     * button click -- see EXPORT_ALL_PER_TICK's own declaration for why. */
+    if (s_export_all_active) {
+        int done = 0;
+        while (s_export_all_active && done < EXPORT_ALL_PER_TICK) {
+            if (s_export_all_idx >= s_asset_n) {
+                s_export_all_active = 0;
+                char msg[256];
+                snprintf(msg, sizeof msg, "Export all done: %d written, %d skipped, into %s",
+                         s_export_all_written, s_export_all_failed, s_export_all_root);
+                say(msg);
+                break;
+            }
+            const AssetEntry *e = &s_assets[s_export_all_idx++];
+            if (export_stock_png(e, s_export_all_root)) s_export_all_written++;
+            else s_export_all_failed++;
+            done++;
+        }
+        if (s_export_all_active) {
+            char msg[256];
+            snprintf(msg, sizeof msg, "Exporting all... %d/%d (%d written)",
+                     s_export_all_idx, s_asset_n, s_export_all_written);
+            say(msg);
+        }
+        s_dirty = 1;
+    }
+    if (!s_win) return;
+    int w = 0, h = 0;
+    SDL_GetRendererOutputSize(s_ren, &w, &h);
+    h = psx_fm_editor_content_height(h);
+    if (w > 0 && h > 0 && (w != s_w || h != s_h)) { if (!ensure_canvas(w, h)) { psx_asset_manager_close(); return; } }
+    {
+        const int on = ((SDL_GetTicks() / 530u) & 1u) == 0u;
+        if (on != s_caret_on) { s_caret_on = on; if (s_search[0]) s_dirty = 1; }
+    }
+    if (s_msg[0] && SDL_GetTicks() >= s_msg_until) { s_msg[0] = 0; s_dirty = 1; }
+    if (s_dirty) { draw(); s_dirty = 0; present_canvas(); }
+}
+
+/* --- the debug side ---------------------------------------------------------
+ *
+ * No View-menu row of its own: this page is reached through the single "FM
+ * Editor" row (psx_tool_window.c) and its tab strip, same as Cards, Drop
+ * Tables, Fusions, Dialogue and CPU -- a second, separate "Asset manager" row
+ * used to open a plain duplicate of this same window and had no reason to. */
+
+void psx_asset_manager_request_open(int open) { s_open_req = open ? 1 : -1; }
+
+static int inject_button(int x, int y, int button, int down)
+{
+    SDL_Event ev;
+    if (!s_win) return 0;
+    SDL_zero(ev);
+    ev.type = down ? SDL_MOUSEBUTTONDOWN : SDL_MOUSEBUTTONUP;
+    ev.button.windowID = SDL_GetWindowID(s_win);
+    ev.button.button = (Uint8)button;
+#if defined(PSX_SDL3)
+    ev.button.down = down ? true : false;
+#else
+    ev.button.state = down ? SDL_PRESSED : SDL_RELEASED;
+#endif
+    ev.button.clicks = 1;
+    ev.button.x = x; ev.button.y = y;
+    return SDL_PushEvent(&ev) == 1;
+}
+
+int psx_asset_manager_click(int x, int y, int button)
+{
+    if (!s_win) return 0;
+    if (button <= 0) button = SDL_BUTTON_LEFT;
+    if (!inject_button(x, y, button, 1)) return 0;
+    return inject_button(x, y, button, 0);
+}
+
+int psx_asset_manager_shot(const char *path)
+{
+    if (!s_win || !s_px || !path) return 0;
+    if (s_dirty) { draw(); s_dirty = 0; }
+    FILE *f = fopen(path, "wb");
+    if (!f) return 0;
+    fprintf(f, "P6\n%d %d\n255\n", s_w, s_h);
+    for (int i = 0; i < s_w * s_h; i++) {
+        const uint32_t c = s_px[i];
+        const unsigned char rgb[3] = { (unsigned char)(c >> 16), (unsigned char)(c >> 8), (unsigned char)c };
+        fwrite(rgb, 1, 3, f);
+    }
+    fclose(f);
+    return 1;
+}
+
+int psx_asset_manager_state_json(char *out, unsigned cap)
+{
+    build_catalog();
+    return (unsigned)snprintf(out, cap,
+        "\"open\":%d,\"categories\":%d,\"assets\":%d,\"cat_sel\":%d,\"asset_sel\":%d,"
+        "\"pack_root\":\"%s\",\"canvas\":[%d,%d],\"unit\":%.3f",
+        s_win != NULL, s_cat_n, s_asset_n, s_cat_sel, s_asset_sel, s_pack_root, s_w, s_h, s_u) < cap;
+}
+
+PSX_MOD_CONSTRUCTOR(psx_asset_manager_install)
+{
+    (void)psx_game_add_frame_hook(tick);
+    (void)psx_game_add_event_hook(on_event);
+}

--- a/src/psx_asset_manager.h
+++ b/src/psx_asset_manager.h
@@ -1,0 +1,25 @@
+/* psx_asset_manager.h -- browse the HD texture pack's catalog, compare stock
+ * art against the pack's replacement, and upload one without leaving the
+ * game. See psx_asset_manager.c for the design. */
+#ifndef PSX_ASSET_MANAGER_H
+#define PSX_ASSET_MANAGER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void psx_asset_manager_open(void);
+void psx_asset_manager_close(void);
+int  psx_asset_manager_is_open(void);
+
+/* --- debug side, same shape as the other tool windows --------------------- */
+void psx_asset_manager_request_open(int open);   /* >0 open, <=0 close */
+int  psx_asset_manager_click(int x, int y, int button);
+int  psx_asset_manager_shot(const char *path);
+int  psx_asset_manager_state_json(char *out, unsigned cap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PSX_ASSET_MANAGER_H */

--- a/src/psx_card_manager.c
+++ b/src/psx_card_manager.c
@@ -41,6 +41,7 @@
 
 #include "host_osd.h"
 #include "mod_plugins.h"
+#include "texture_pack.h"          /* arms the raw HD injector after a Pick art/thumb/title */
 #include "psx_card_db.h"
 #include "psx_card_packs.h"
 #include "psx_card_effects.h"
@@ -1788,13 +1789,14 @@ static void do_open_folder(void)
     say("Opened the card's folder");
 }
 
+/* Writes into the active HD texture pack's own shared folder -- the same
+ * "Card assets/card artworks|thumbnails|Titles/<id>.png" the Asset Manager
+ * reads and writes -- so picking a card's art here and uploading it there are
+ * the same action on the same file, not two folders quietly disagreeing. */
 static int install_pick(const char *src, int kind)
 {
-    static const char *const names[4] = { "", "art.png", "thumb.png", "title.png" };
     char dst[1200];
-    card_folder(dst, sizeof dst, 1);
-    const size_t n = strlen(dst);
-    snprintf(dst + n, sizeof dst - n, "/%s", names[kind]);
+    psx_card_packs_art_dest_path(s_sel, kind, dst, sizeof dst);
     FILE *in = psx_fopen_utf8(src, "rb");
     if (!in) return 0;
     FILE *out = psx_fopen_utf8(dst, "wb");
@@ -1803,6 +1805,18 @@ static int install_pick(const char *src, int kind)
     size_t got;
     while ((got = fread(buf, 1, sizeof buf, in)) > 0) fwrite(buf, 1, got, out);
     fclose(in); fclose(out);
+    /* Arm the raw VRAM injector on this same folder (a no-op if it already
+     * is) and ask it to re-read its files: the pick above just wrote a new
+     * one, and without this the injector's cached listing would not know it
+     * exists until something else happened to trigger a rescan. This is
+     * what lets the picture show at full resolution instead of stock (see
+     * build_disc_side() in psx_card_packs.c) -- deliberately only done here
+     * and on the Textures page opening, both explicit player actions, not
+     * at boot. */
+    char root[1024];
+    texpack_active_dir(root, sizeof root);
+    texpack_set_active_dir(root);
+    texpack_request_reload();
     return 1;
 }
 
@@ -2120,7 +2134,7 @@ static void draw_editor(void)
         psx_ui_text(&s_cv, L->info_x, y + psx_ui_font_ascent(fs), s_edit.has_art ? "Face art: yours" : "Face art: stock", s_edit.has_art ? COL_EDITED : COL_DIM, fs); y += lh;
         psx_ui_text(&s_cv, L->info_x, y + psx_ui_font_ascent(fs), s_edit.has_thumb ? "Duel thumbnail: yours" : "Duel thumbnail: stock", s_edit.has_thumb ? COL_EDITED : COL_DIM, fs); y += lh;
         psx_ui_text(&s_cv, L->info_x, y + psx_ui_font_ascent(fs), s_edit.has_title ? "Title strip: yours (96x14)" : "Title strip: from the name (96x14)", s_edit.has_title ? COL_EDITED : COL_DIM, fs); y += lh + px(4.0f);
-        draw_wrapped(L->info_x, y, iw, "Any PNG works for the face; it becomes 102x96 in 256 colors. The duel thumbnail is 40x32 in 64 colors and is made from the face unless you pick one. The title strip is the 96x14 name banner and is drawn from the name unless you pick one. A change shows on the next screen that draws the card.", COL_DIM, fs, 5);
+        draw_wrapped(L->info_x, y, iw, "Any PNG works for the face; it becomes 102x96 in the Textures folder. The duel thumbnail is 40x32 and needs its own picture -- nothing is derived from the face any more. The title strip is the 96x14 name banner and is drawn from the name unless you pick one. A change shows on the next screen that draws the card.", COL_DIM, fs, 5);
     }
     }
     /* fields */

--- a/src/psx_card_packs.c
+++ b/src/psx_card_packs.c
@@ -10,15 +10,25 @@
  *                  level = 12             attribute = Light  (name or 0..7)
  *                  price = 999999         password = 12345678
  *                  Every key is optional; a missing key keeps the stock value.
- *     art.png      the card face art. Any size; scaled to 102x96, 256 colors.
- *     thumb.png    the duel thumbnail. Any size; scaled to 40x32, 64 colors.
- *                  Without one, the middle 80x64 of the art, halved (the
- *                  stock thumbnails are zooms, not the face squashed).
- *                  Derived from art.png when absent.
- *     title.png    the baked title strip, 96x14, dark ink on white or with
- *                  alpha. Rendered from `name` when absent (Times New Roman
- *                  Bold from <player-data>/cards/timesbd.ttf, or the old
- *                  card_skins/ copy, or the duel text font as a last resort).
+ *
+ * PICTURES (since 2026-09-13, no longer part of the folder above)
+ *     Card art, the duel thumbnail, and the title strip live in the active
+ *     HD texture pack's own shared folder -- <player-data>/textures/Card
+ *     assets/card artworks|thumbnails|Titles/<id>.png -- the exact slots
+ *     psx_wa_catalog.c's DISPLAY_RULES already curate and the Asset Manager
+ *     already reads and writes, so uploading through either window is one
+ *     file, and nothing in a card's own folder is a picture any more.
+ *     Nothing there means stock; there is no second (legacy per-card)
+ *     folder checked first. See art_shared_path()/psx_card_packs_art_path()
+ *     for the exact layout, and build_disc_side() for why the disc's own
+ *     bytes are left at stock even when a picture exists -- that is what
+ *     lets the raw VRAM injector do the actual substituting, at whatever
+ *     resolution the file really is, instead of a 256-or-64-color disc
+ *     record. The one true fallback-to-generated-content that remains: a
+ *     renamed card with no title picture still gets its name rendered into
+ *     a strip (Times New Roman Bold from <player-data>/cards/timesbd.ttf,
+ *     or the old card_skins/ copy, or the duel text font as a last resort),
+ *     since there is no on-disc "stock title" for a name that never existed.
  *
  * WHERE EACH FIELD LIVES, MEASURED (2026-09-04, sector history + RAM):
  *
@@ -74,6 +84,8 @@
 
 #include "cdrom.h"
 #include "mod_plugins.h"
+#include "texture_pack.h"          /* texpack_active_dir() -- the shared pack folder */
+#include "psx_texture_export.h"    /* psx_texture_export_mkdir_p() */
 #include "psx_game_hooks.h"
 #include "psx_card_db.h"
 #include "psx_card_extend.h"
@@ -111,12 +123,9 @@
 #define TITLE_W 96
 #define TITLE_H 14
 #define TITLE_BYTES    (TITLE_W / 2 * TITLE_H)      /* 672 */
-#define THUMB_OFF      10976
 #define THUMB_W 40
 #define THUMB_H 32
 #define THUMB_BYTES    (THUMB_W * THUMB_H)          /* 1280 */
-#define THUMB_CLUT_OFF (THUMB_OFF + THUMB_BYTES)    /* 12256 */
-#define THUMB_TOTAL    (THUMB_BYTES + 128)          /* 1408 */
 
 #define STATS_STOCK    0x801D4244u
 #define AUX_STOCK      0x801D5332u
@@ -706,6 +715,60 @@ static long file_mtime(const char *path)
     if (stat(path, &st) != 0) return 0;
     return (long)st.st_mtime ^ (long)(st.st_size << 8);
 }
+
+/* ---- where art.png / thumb.png / title.png actually live -----------------
+ *
+ * Before 2026-09-12 all three lived in this card's own folder alongside
+ * card.ini. Since 2026-09-13 that per-card folder no longer carries pictures
+ * at all: the only place any of the three is ever looked for is the Asset
+ * Manager's HD texture pack's own curated slot -- "Card assets/card
+ * artworks|thumbnails|Titles/%03d.png" under the active pack's own folder,
+ * from psx_wa_catalog.c's DISPLAY_RULES -- so uploading a card's art through
+ * either window is the same file, and a player's whole mod is one pack
+ * folder, not that plus a second one just for cards. Nothing there for a
+ * given field means stock; there is no second folder to fall back to first
+ * any more.
+ *
+ * The card's own folder is still where card.ini (its text/stats edit) lives
+ * -- that is not a picture, and is unaffected by any of this. */
+static const char *const ART_SUB[4]  = { "", "Card assets/card artworks",
+                                         "Card assets/card thumbnails", "Card assets/card Titles" };
+
+static void art_shared_path(int id, int kind, char *out, size_t cap)
+{
+    char root[1024];
+    texpack_active_dir(root, (unsigned)sizeof root);
+    snprintf(out, cap, "%s/%s/%03d.png", root, ART_SUB[kind], id);
+}
+
+/* The card's own per-id folder no longer carries pictures at all (removed
+ * 2026-09-13, along with duelists/<id>/portrait.png for CPU -- see
+ * psx_cpu_data.c): every picture lookup is now exactly one place, the
+ * shared Textures folder, same as the Asset Manager's own browsing tree.
+ * Whatever is not there is stock -- no second folder to fall back to first.
+ * card.ini (name/stats/effects) is unaffected; it is not a picture and still
+ * lives in the card's own folder (pack_path()). */
+void psx_card_packs_art_path(int id, int kind, char *out, unsigned cap)
+{
+    if (!out || !cap) return;
+    if (kind < 1 || kind > 3) { out[0] = 0; return; }
+    art_shared_path(id, kind, out, cap);
+}
+
+void psx_card_packs_art_dest_path(int id, int kind, char *out, unsigned cap)
+{
+    if (!out || !cap) return;
+    if (kind < 1 || kind > 3) { out[0] = 0; return; }
+    art_shared_path(id, kind, out, cap);
+    char dir[1200]; snprintf(dir, sizeof dir, "%s", out);
+    char *slash = strrchr(dir, '/');
+    if (slash) { *slash = 0; psx_texture_export_mkdir_p(dir); }
+}
+
+/* Local shorthand for the three call sites below that used to pass a literal
+ * "art.png"/"thumb.png"/"title.png" straight to pack_path(): resolve through
+ * the shared-then-own-folder rule above instead. */
+static void art_path(int id, int kind, char *out, size_t cap) { psx_card_packs_art_path(id, kind, out, (unsigned)cap); }
 
 static unsigned char *read_file(const char *path, long *size)
 {
@@ -1476,48 +1539,59 @@ static int build_disc_side(Pack *pk)
 {
     const int id = pk->cfg.id;
     static uint8_t rec[REC_SECTORS * SECTOR];
-    static uint8_t art_rgb[ART_BYTES * 3], thumb_rgb[THUMB_BYTES * 3];
-    static uint8_t idx[ART_BYTES];
-    static uint16_t clut[256];
+    static uint8_t thumb_rgb[THUMB_BYTES * 3];
+    static uint8_t thumb_idx[THUMB_BYTES];
+    static uint16_t thumb_clut[64];
     char path[1200];
     int have_art = 0, have_thumb = 0, have_title = 0;
+    int title_override = 0, thumb_duel_override = 0;
 
     if (!read_stock_record(id, rec)) return 0;
 
-    pack_path(id, "art.png", path, sizeof path);
-    if (load_png_rgb(path, ART_W, ART_H, art_rgb)) {
-        quantize(art_rgb, ART_BYTES, 256, idx, clut);
-        memcpy(rec, idx, ART_BYTES);
-        for (int i = 0; i < 256; i++) { rec[ART_CLUT_OFF + i * 2] = (uint8_t)clut[i]; rec[ART_CLUT_OFF + i * 2 + 1] = (uint8_t)(clut[i] >> 8); }
-        have_art = 1;
-    }
-    pack_path(id, "thumb.png", path, sizeof path);
-    if (load_png_rgb(path, THUMB_W, THUMB_H, thumb_rgb)) have_thumb = 1;
-    else if (have_art) {
-        /* The stock thumbnails are not the face shrunk: each is a zoom on the
-         * monster, a 5:4 window that is the whole face on a few cards and a
-         * third of it on others. Measured over 68 cards (2026-09-07, the
-         * crop of the stock face that best matches the stock thumbnail), the
-         * window is 74 px wide in the median, centred at x 50 and y 40, so
-         * a little above the middle where the heads are. This takes the
-         * 80x64 window on that centre, which is exactly a 2x2 average, and
-         * which beat the whole-face squash on every card measured. A card
-         * whose subject sits elsewhere gets its own thumb.png. */
-        shrink_rgb(art_rgb, ART_W, (ART_W - THUMB_W * 2) / 2, 8, THUMB_W * 2, THUMB_H * 2, thumb_rgb, THUMB_W, THUMB_H);
-        have_thumb = 1;
-    }
+    /* FACE: exists in the shared Textures folder, or it is stock -- there is
+     * no second folder to fall back to any more, and no quantized override
+     * either way. Leaving the art record's bytes at stock regardless is what
+     * lets the raw VRAM injector ("cards/art/%03d", psx_wa_catalog.c)
+     * substitute the shared file at full resolution wherever the face is
+     * actually drawn; "nothing to substitute" is exactly what should read as
+     * stock. */
+    psx_card_packs_art_path(id, PSX_CARD_ART_FACE, path, sizeof path);
+    have_art = file_mtime(path) != 0;
+
+    /* THUMBNAIL: two on-disc copies of the very same picture (see the file
+     * header). The art record's own copy -- what the password screen, card
+     * chest and library page draw, registered as "cards/mini/%03d" -- gets
+     * the same stock-bytes-stay-stock treatment as the face. The DUEL's copy
+     * (THUMB_LBA, a separate stream in a different layout entirely -- WA_MRG
+     * sector id-1, nothing to do with the art record's byte offsets) has no
+     * injector registration of its own, so it is the one place a picture
+     * still gets quantized into a classic override -- but only from this
+     * card's own "cards/mini" file. No more deriving one from the face when
+     * there is no dedicated thumbnail: nothing there means stock. */
+    psx_card_packs_art_path(id, PSX_CARD_ART_THUMB, path, sizeof path);
+    have_thumb = load_png_rgb(path, THUMB_W, THUMB_H, thumb_rgb);
     if (have_thumb) {
-        quantize(thumb_rgb, THUMB_BYTES, 64, idx, clut);
-        memcpy(rec + THUMB_OFF, idx, THUMB_BYTES);
-        for (int i = 0; i < 64; i++) { rec[THUMB_CLUT_OFF + i * 2] = (uint8_t)clut[i]; rec[THUMB_CLUT_OFF + i * 2 + 1] = (uint8_t)(clut[i] >> 8); }
+        quantize(thumb_rgb, THUMB_BYTES, 64, thumb_idx, thumb_clut);
+        thumb_duel_override = 1;
     }
-    pack_path(id, "title.png", path, sizeof path);
-    if (load_title_png(path, rec + TITLE_OFF)) have_title = 1;
-    else if (pk->cfg.name[0]) { render_title(pk->cfg.name, rec + TITLE_OFF); have_title = 1; }
+
+    /* TITLE: same "stock unless the shared file exists" rule as the face,
+     * with one exception -- a renamed card has no on-disc "stock title for a
+     * name that never existed" to fall back to, so the name is still
+     * rendered into a strip whenever there is no shared file AND the name
+     * has actually been edited. That is not a picture fallback; it is text
+     * the disc genuinely cannot already have a picture of. */
+    psx_card_packs_art_path(id, PSX_CARD_ART_TITLE, path, sizeof path);
+    have_title = file_mtime(path) != 0;
+    if (!have_title && pk->cfg.name[0]) {
+        render_title(pk->cfg.name, rec + TITLE_OFF);
+        title_override = 1;
+        have_title = 1;
+    }
 
     pk->cfg.has_art = have_art; pk->cfg.has_thumb = have_thumb; pk->cfg.has_title = have_title;
 
-    if (have_art || have_thumb || have_title) {
+    if (title_override) {
         for (int s = 0; s < REC_SECTORS; s++)
             psx_mod_cd_override_set(REC_LBA(id) + (uint32_t)s, rec + s * SECTOR, SECTOR);
         pk->rec_override = 1;
@@ -1525,10 +1599,11 @@ static int build_disc_side(Pack *pk)
         for (int s = 0; s < REC_SECTORS; s++) psx_mod_cd_override_clear(REC_LBA(id) + (uint32_t)s);
         pk->rec_override = 0;
     }
-    if (have_thumb) {
+    if (thumb_duel_override) {
         static uint8_t sec[SECTOR];
         if (psx_mod_cd_read_stock_sector(THUMB_LBA(id), sec)) {
-            memcpy(sec, rec + THUMB_OFF, THUMB_TOTAL);
+            memcpy(sec, thumb_idx, THUMB_BYTES);
+            for (int i = 0; i < 64; i++) { sec[THUMB_BYTES + i * 2] = (uint8_t)thumb_clut[i]; sec[THUMB_BYTES + i * 2 + 1] = (uint8_t)(thumb_clut[i] >> 8); }
             psx_mod_cd_override_set(THUMB_LBA(id), sec, SECTOR);
             pk->thumb_override = 1;
         }
@@ -1742,19 +1817,24 @@ static void assert_ram(void)
     }
 }
 
+/* mtime[0] is card.ini, in the card's own folder as always; mtime[1..3] are
+ * art/thumb/title, resolved through art_path() so a file appearing in (or
+ * vanishing from, or the active pack switching under) the shared folder is
+ * noticed exactly like an edit to the card's own copy always was. */
 static void note_mtimes(Pack *pk)
 {
-    static const char *const files[4] = { "card.ini", "art.png", "thumb.png", "title.png" };
     char path[1200];
-    for (int i = 0; i < 4; i++) { pack_path(pk->cfg.id, files[i], path, sizeof path); pk->mtime[i] = file_mtime(path); }
+    pack_path(pk->cfg.id, "card.ini", path, sizeof path); pk->mtime[0] = file_mtime(path);
+    for (int i = 1; i < 4; i++) { art_path(pk->cfg.id, i, path, sizeof path); pk->mtime[i] = file_mtime(path); }
 }
 
 static int mtimes_changed(const Pack *pk)
 {
-    static const char *const files[4] = { "card.ini", "art.png", "thumb.png", "title.png" };
     char path[1200];
-    for (int i = 0; i < 4; i++) {
-        pack_path(pk->cfg.id, files[i], path, sizeof path);
+    pack_path(pk->cfg.id, "card.ini", path, sizeof path);
+    if (file_mtime(path) != pk->mtime[0]) return 1;
+    for (int i = 1; i < 4; i++) {
+        art_path(pk->cfg.id, i, path, sizeof path);
         if (file_mtime(path) != pk->mtime[i]) return 1;
     }
     return 0;
@@ -1777,9 +1857,9 @@ static void load_pack(int id)
     cfg_reset(&pk->cfg, id);
     const int ini = read_ini(id, &pk->cfg);
     char path[1200];
-    pack_path(id, "art.png", path, sizeof path);   const int art = file_mtime(path) != 0;
-    pack_path(id, "thumb.png", path, sizeof path); const int thumb = file_mtime(path) != 0;
-    pack_path(id, "title.png", path, sizeof path); const int title = file_mtime(path) != 0;
+    art_path(id, PSX_CARD_ART_FACE, path, sizeof path);  const int art = file_mtime(path) != 0;
+    art_path(id, PSX_CARD_ART_THUMB, path, sizeof path); const int thumb = file_mtime(path) != 0;
+    art_path(id, PSX_CARD_ART_TITLE, path, sizeof path); const int title = file_mtime(path) != 0;
     pk->present = ini || art || thumb || title;
     take_stock(pk);
     note_mtimes(pk);
@@ -1965,6 +2045,10 @@ int psx_card_packs_remove(int id)
     static const char *const files[4] = { "card.ini", "art.png", "thumb.png", "title.png" };
     char path[1200];
     for (int i = 0; i < 4; i++) { pack_path(id, files[i], path, sizeof path); remove(path); }
+    /* Also whichever of the three the shared pack folder is holding: "restore
+     * stock" means stock everywhere, not stock in this card's own folder
+     * while the Asset Manager's copy quietly keeps drawing. */
+    for (int k = 1; k < 4; k++) { art_shared_path(id, k, path, sizeof path); remove(path); }
     pack_path(id, NULL, path, sizeof path);
 #ifdef _WIN32
     _rmdir(path);
@@ -1981,11 +2065,20 @@ void psx_card_packs_reload(int id)
     if (s_pw_dirty) rebuild_password_table();
 }
 
+/* The face preview: the resolved PNG's own pixels first -- whether or not
+ * this card's disc bytes are actually overridden with them, since a shared
+ * HD file deliberately is NOT written into the disc record any more (see
+ * build_disc_side()) so the raw VRAM injector can substitute it in the real
+ * game instead. Reading only the disc would show "stock" for exactly the
+ * cards this player has replaced. Falls back to the disc (override, else
+ * stock) only when there is no file to decode at all. */
 int psx_card_packs_art_rgb(int id, uint8_t *out)
 {
     if (id < 1 || id > CARD_COUNT || !out) return 0;
+    char path[1200];
+    psx_card_packs_art_path(id, PSX_CARD_ART_FACE, path, sizeof path);
+    if (load_png_rgb(path, ART_W, ART_H, out)) return 1;
     static uint8_t rec[REC_SECTORS * SECTOR];
-    /* the override when present, else stock: read through the same LBAs */
     for (int s = 0; s < REC_SECTORS; s++) {
         const uint32_t lba = REC_LBA(id) + (uint32_t)s;
         int ok = 0;
@@ -1998,9 +2091,15 @@ int psx_card_packs_art_rgb(int id, uint8_t *out)
     return 1;
 }
 
+/* Same idea as psx_card_packs_art_rgb(), and for the same reason -- plus it
+ * shows the source picture instead of the 64-color quantized copy the duel
+ * stream actually carries, which is a truer preview of "yours" either way. */
 int psx_card_packs_thumb_rgb(int id, uint8_t *out)
 {
     if (id < 1 || id > CARD_COUNT || !out) return 0;
+    char path[1200];
+    psx_card_packs_art_path(id, PSX_CARD_ART_THUMB, path, sizeof path);
+    if (load_png_rgb(path, THUMB_W, THUMB_H, out)) return 1;
     static uint8_t sec[SECTOR];
     int ok = 0;
     if (s_packs[id] && s_packs[id]->thumb_override) {
@@ -2212,21 +2311,45 @@ static void card_packs_tick(void)
         { extern int psx_host_menu_settings_save(void); (void)psx_host_menu_settings_save(); }
     }
     frames++;
-    /* Hot reload: known packs every second, the whole tree every ten. */
+    /* Hot reload, known cards: every second. Cheap -- only the cards already
+     * tracked as present, normally a handful. */
     if ((frames % 60u) == 0u) {
         int changed = 0;
         for (int id = 1; id <= CARD_COUNT; id++)
             if (s_packs[id] && s_packs[id]->present && mtimes_changed(s_packs[id])) { load_pack(id); changed = 1; }
-        if ((frames % 600u) == 0u) {
-            for (int id = 1; id <= CARD_COUNT; id++) {
-                if (s_packs[id] && s_packs[id]->present) continue;
-                char path[1200];
-                pack_path(id, NULL, path, sizeof path);
-                struct stat st;
-                if (stat(path, &st) == 0) { load_pack(id); changed = 1; }
-            }
-        }
         if (changed || s_pw_dirty) rebuild_password_table();
+    }
+    /* Hot reload, brand-new cards: a small batch every frame instead of the
+     * whole table on a timer. A card whose only content is a shared-pack
+     * upload (no card.ini, no folder of its own) has no Pack struct at all
+     * until this notices it -- doing that check for all 722 cards at once,
+     * even on a once-a-second timer, is a burst of 700+ stat() calls in a
+     * single frame that got worse the longer a player had been testing (more
+     * files on disk to stat). NOTICE_PER_TICK cards a frame instead spreads
+     * the exact same total cost thin enough that no one frame notices it,
+     * while still covering the whole table roughly twice a second at 60 fps. */
+    {
+        enum { NOTICE_PER_TICK = 8 };
+        static int cursor = 1;
+        int changed = 0;
+        for (int n = 0; n < NOTICE_PER_TICK; n++) {
+            if (cursor > CARD_COUNT) cursor = 1;
+            const int id = cursor++;
+            if (s_packs[id] && s_packs[id]->present) continue;
+            char path[1200];
+            struct stat st;
+            pack_path(id, NULL, path, sizeof path);
+            int found = stat(path, &st) == 0;
+            for (int k = 1; !found && k < 4; k++) {
+                art_path(id, k, path, sizeof path);
+                found = file_mtime(path) != 0;
+            }
+            if (found) { load_pack(id); changed = 1; }
+        }
+        /* s_pw_dirty alone is already covered by the once-a-second block
+         * above within a second; this loop only needs to react to what it
+         * itself just found. */
+        if (changed) rebuild_password_table();
     }
     assert_ram();
 }

--- a/src/psx_card_packs.h
+++ b/src/psx_card_packs.h
@@ -252,6 +252,21 @@ typedef struct {
 
 /* Player folder holding the packs (".../cards"); "" before boot. */
 const char *psx_card_packs_dir(void);
+
+/* Which of the three pictures: matches psx_card_manager.c's existing Pick
+ * art/thumb/title button kinds, so a caller does not need a second enum. */
+enum { PSX_CARD_ART_FACE = 1, PSX_CARD_ART_THUMB = 2, PSX_CARD_ART_TITLE = 3 };
+/* Where this card's art/thumb/title actually is: the active HD texture
+ * pack's own shared folder -- "Card assets/card artworks/<id>.png" and its
+ * two siblings, the exact slot the Asset Manager reads and writes. Always
+ * fills `out`, whether or not the file actually exists there (a missing
+ * file is stock; there is no second folder checked first any more). */
+void psx_card_packs_art_path(int id, int kind, char *out, unsigned cap);
+/* Where a NEW upload of that kind should be written: the active pack's
+ * shared folder (creating whatever directories that needs), so uploading a
+ * card's art through the Card Manager and through the Asset Manager land on
+ * the one file. */
+void psx_card_packs_art_dest_path(int id, int kind, char *out, unsigned cap);
 /* The player's OWN set, <player-data>/cards, whichever set is live. What a
  * share file or a revert must address: the Dev Card Effects set is a
  * shipped mod and is never what a player means by "my cards". */

--- a/src/psx_cpu_data.c
+++ b/src/psx_cpu_data.c
@@ -81,15 +81,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #ifdef _WIN32
 #include <direct.h>
 #define rmdir _rmdir
 #else
-#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
 #include "mod_plugins.h"
+#include "texture_pack.h"          /* texpack_active_dir() -- the shared pack folder */
+#include "psx_texture_export.h"    /* psx_texture_export_mkdir_p() */
 #include "psx_card_packs.h"
 #include "psx_card_share.h"      /* the zip container a .ygoduelists file is */
 #include "psx_drop_db.h"
@@ -145,14 +147,14 @@
 typedef char cpu_name_arena_fits[(NAME_ARENA + 39u * NAME_SLOT <= 0x801DA000u) ? 1 : -1];
 typedef char cpu_name_arena_above_packs[(NAME_ARENA >= PSX_CARD_PACKS_NAMES_LIMIT) ? 1 : -1];
 
-/* the portrait tiles: WA_MRG sector 0x1EAA, forty 2432-byte tiles */
-#define TILE_LBA      17952u
-#define TILE_BYTES    2432u
+/* the portrait tile size (48x48). The disc-side layout this used to also
+ * describe -- WA_MRG sector 0x1EAA, forty 2432-byte tiles, TILE_LBA/
+ * TILE_SECTORS/TILE_CLUT -- went away with the TILE_LBA override itself
+ * (see portraits_install()'s own comment): every portrait now comes from
+ * the shared Textures folder alone, decoded straight to RGB with no
+ * quantized disc copy to size or address. */
 #define TILE_W        48
-#define TILE_PIXELS   (TILE_W * TILE_W)          /* 2304 indices */
-#define TILE_CLUT     64
-#define TILES         40u
-#define TILE_SECTORS  ((TILES * TILE_BYTES + SECTOR - 1u) / SECTOR)   /* 48 */
+#define TILE_PIXELS   (TILE_W * TILE_W)          /* 2304 pixels */
 
 /* ---- state ---------------------------------------------------------------- */
 
@@ -170,6 +172,7 @@ typedef struct {
 } CpuEdit;
 
 static CpuEdit  g_edit[NDUEL];
+static long     s_portrait_mtime[NDUEL];   /* hot-reload watch, see tick() */
 static uint8_t  g_ai_stock[NDUEL][PSX_CPU_AI_BYTES];
 static int      g_ai_stock_ready;
 static uint16_t g_name_stock[NDUEL];     /* the stock offset-table entries */
@@ -414,16 +417,19 @@ static int install_deck(int duelist)
 
 /* ---- the portrait ----------------------------------------------------------
  *
- * Replacing one is the card-art pipeline pointed at a different target: the
- * PNG is scaled to 48x48, quantised to 64 colors and written back as indices
- * plus a CLUT. The whole 48-sector block is rebuilt from the stock sectors
- * every time, so the overrides are always stock plus exactly the portraits
- * the player has replaced -- there is no accumulated state to get wrong.
- *
- * The STP bit goes on every CLUT entry because the stock tiles carry it (the
- * portraits are solid squares, and black without STP keys out), and
- * psx_duelist_portraits.c refuses a block that does not have it. */
+ * Lives in the active HD texture pack's shared folder alone (see
+ * portrait_png_shared() below) -- nothing there means stock, no per-duelist
+ * folder to check first. The disc's own tile block is never touched any
+ * more (see portraits_install()'s own comment for why): the picture only
+ * ever reaches the windows as an in-memory override, at its real decoded
+ * colors, and reaches the actual Free Duel select screen through the raw
+ * VRAM injector, which is registered for this same file. */
 
+/* The pre-2026-09-13 location. No longer read or written to -- every
+ * portrait lookup goes through portrait_png_shared() now, same single
+ * folder as the Asset Manager, with nothing there meaning stock and no
+ * second folder to fall back to. Kept only so psx_cpu_portrait_clear() can
+ * tidy away a leftover file/folder from before this change. */
 static void portrait_dir(int duelist, char *out, size_t cap)
 {
     const char *dir = psx_mod_player_data_dir();
@@ -445,6 +451,50 @@ static int file_exists(const char *p)
     return 1;
 }
 
+static long file_mtime(const char *p)
+{
+    struct stat st;
+    if (stat(p, &st) != 0) return 0;
+    return (long)st.st_mtime ^ (long)(st.st_size << 8);
+}
+
+/* The active HD texture pack's own slot for this portrait -- "Free duel/
+ * portraits/%03d.png" under the active pack's folder, from psx_wa_catalog.c's
+ * DISPLAY_RULES ("free_duel/portrait_%03d", first=0, so record d+1 is this
+ * duelist's -- the same +1 the duelists/<id> folder above already uses).
+ * Uploading a duelist's portrait through the CPU Manager and through the
+ * Asset Manager now land on the one file. */
+static void portrait_png_shared(int duelist, char *out, size_t cap)
+{
+    char root[1024];
+    texpack_active_dir(root, (unsigned)sizeof root);
+    /* "portrait_" is part of the LEAF, not a separator -- psx_wa_catalog.c's
+     * DISPLAY_RULES has this row's name_fmt as "free_duel/portrait_%03d", and
+     * the leaf is everything after the family's own slash, so it really is
+     * "portrait_001.png", not "001.png". Dropping that prefix here (as an
+     * earlier pass did) meant this never matched a single file the Asset
+     * Manager actually wrote. */
+    snprintf(out, cap, "%s/Free duel/portraits/portrait_%03d.png", root, duelist + 1);
+}
+
+/* Where this duelist's portrait actually is: the shared folder, full stop --
+ * same rule psx_card_packs.c uses for card art, for the same reason. Nothing
+ * there means stock; there is no second folder to check first any more. */
+static void portrait_path_resolve(int duelist, char *out, size_t cap)
+{
+    portrait_png_shared(duelist, out, cap);
+}
+
+/* Where a NEW portrait upload is written: always the shared folder, creating
+ * whatever directories that needs. */
+static void portrait_path_dest(int duelist, char *out, size_t cap)
+{
+    portrait_png_shared(duelist, out, cap);
+    char dir[1200]; snprintf(dir, sizeof dir, "%s", out);
+    char *slash = strrchr(dir, '/');
+    if (slash) { *slash = 0; psx_texture_export_mkdir_p(dir); }
+}
+
 int psx_cpu_portrait_edited(int duelist)
 {
     psx_cpu_ensure_loaded();
@@ -459,60 +509,38 @@ int psx_cpu_portraits_count(void)
     return n;
 }
 
-/* Rebuild the whole tile block from stock, paint every replaced portrait into
- * it, and override the sectors. Returns how many portraits were painted, or
- * -1 when the stock sectors could not be read. */
+/* Feed every replaced portrait to the windows (CPU Manager, Drop Table
+ * Viewer, and psx_duelist_portraits_get() generally) as an in-memory
+ * override, and clear the rest back to none. Returns how many were painted.
+ *
+ * This used to ALSO quantize each one to 64 colors and bake it into a
+ * TILE_LBA disc-sector override, the classic "one folder or the other"
+ * per-duelist choice build_disc_side() makes for cards (psx_card_packs.c).
+ * Removed 2026-09-13 along with the legacy duelists/<id>/portrait.png
+ * folder itself: there is only one on-disc copy of this picture (unlike
+ * cards' art record vs. duel-stream split), and it IS registered with the
+ * raw VRAM injector ("free_duel/portrait_%03d", psx_wa_catalog.c), so
+ * leaving the disc bytes at stock unconditionally is what lets the injector
+ * (or plain stock, when the "HD textures" toggle is off) own the Free Duel
+ * select screen outright -- no override left to fight it, and no need to
+ * quantize down to 64 colors for a picture that never touches the disc any
+ * more. The windows get the true decoded colors instead of that quantized
+ * copy, for the same reason psx_card_packs_art_rgb() does. */
 static int portraits_install(void)
 {
-    static uint8_t block[TILE_SECTORS * SECTOR];
-    int painted = 0, any = 0;
-    for (int d = 0; d < NDUEL; d++) any += g_edit[d].portrait_set != 0;
-    if (!any) {
-        for (uint32_t sct = 0; sct < TILE_SECTORS; sct++) psx_mod_cd_override_clear(TILE_LBA + sct);
-        return 0;
-    }
-    for (uint32_t sct = 0; sct < TILE_SECTORS; sct++)
-        if (!psx_mod_cd_read_stock_sector(TILE_LBA + sct, block + sct * SECTOR)) return -1;
+    int painted = 0;
     for (int d = 0; d < NDUEL; d++) {
-        if (!g_edit[d].portrait_set) continue;
+        if (!g_edit[d].portrait_set) { psx_duelist_portraits_override(d, NULL); continue; }
         char png[1200];
-        portrait_png(d, png, sizeof png);
+        portrait_path_resolve(d, png, sizeof png);
         static uint8_t rgb[TILE_PIXELS * 3];
-        if (!psx_card_packs_load_png_rgb(png, TILE_W, TILE_W, rgb)) continue;
-        static uint8_t idx[TILE_PIXELS];
-        uint16_t clut[TILE_CLUT];
-        /* PIXELS, not bytes. With the byte count the quantiser ran over
-         * 6912 "pixels": it read on past rgb into the tile block, and wrote
-         * indices past idx into rgb -- which sits right after it -- so the
-         * first 32 rows of the picture were being replaced by index bytes
-         * while it was still being read. On the grid that was green specks
-         * across the face with a one-pass quantiser, and 30-40 rows of
-         * noise over a face once the quantiser made a second pass (found
-         * 2026-09-08, from a player's Duel Master K). */
-        psx_card_packs_quantize(rgb, TILE_PIXELS, TILE_CLUT, idx, clut);
-        uint8_t *tile = block + (uint32_t)(d + 1) * TILE_BYTES;
-        for (int i = 0; i < TILE_PIXELS; i++) tile[i] = (uint8_t)(idx[i] & 63u);
-        for (int k = 0; k < TILE_CLUT; k++) {
-            const uint16_t c = (uint16_t)(clut[k] | 0x8000u);   /* STP, as stock */
-            tile[TILE_PIXELS + 2 * k]     = (uint8_t)(c & 0xFFu);
-            tile[TILE_PIXELS + 2 * k + 1] = (uint8_t)(c >> 8);
-        }
-        {   /* hand the same pixels to the windows, in the colours the game
-             * will draw: they decode the STOCK sectors and cannot see an
-             * override. */
-            static uint32_t argb[TILE_PIXELS];
-            for (int i = 0; i < TILE_PIXELS; i++) {
-                const unsigned c = clut[idx[i] & 63u];
-                const unsigned r = (c & 31u) << 3, g = ((c >> 5) & 31u) << 3, b = ((c >> 10) & 31u) << 3;
-                argb[i] = 0xFF000000u | (r << 16) | (g << 8) | b;
-            }
-            psx_duelist_portraits_override(d, argb);
-        }
+        if (!psx_card_packs_load_png_rgb(png, TILE_W, TILE_W, rgb)) { psx_duelist_portraits_override(d, NULL); continue; }
+        static uint32_t argb[TILE_PIXELS];
+        for (int i = 0; i < TILE_PIXELS; i++)
+            argb[i] = 0xFF000000u | ((uint32_t)rgb[i * 3] << 16) | ((uint32_t)rgb[i * 3 + 1] << 8) | rgb[i * 3 + 2];
+        psx_duelist_portraits_override(d, argb);
         painted++;
     }
-    for (uint32_t sct = 0; sct < TILE_SECTORS; sct++)
-        if (!psx_mod_cd_override_set(TILE_LBA + sct, block + sct * SECTOR, SECTOR)) return -1;
-    psx_duelist_portraits_reload();
     return painted;
 }
 
@@ -529,24 +557,13 @@ int psx_cpu_portrait_set(int duelist, const char *png_path, char *msg, unsigned 
         if (msg && cap) snprintf(msg, cap, "That file is not a picture this can read");
         return 0;
     }
-    /* Keep the player's own PNG: it is what survives a restart, and what
-     * they can replace by hand. */
-    char dir[1024], dest[1200];
-    const char *pd = psx_mod_player_data_dir();
-    char base[1100];
-    snprintf(base, sizeof base, "%s/duelists", pd && pd[0] ? pd : ".");
-#ifdef _WIN32
-    (void)_mkdir(base);
-#else
-    (void)mkdir(base, 0755);
-#endif
-    portrait_dir(duelist, dir, sizeof dir);
-#ifdef _WIN32
-    (void)_mkdir(dir);
-#else
-    (void)mkdir(dir, 0755);
-#endif
-    portrait_png(duelist, dest, sizeof dest);
+    /* Keep the player's own PNG, in the active HD texture pack's own shared
+     * folder -- the same "Free duel/portraits/<id>.png" the Asset Manager
+     * reads and writes -- so picking a portrait here and uploading one there
+     * are the same action on the same file. It is what survives a restart,
+     * and what they can replace by hand. */
+    char dest[1200];
+    portrait_path_dest(duelist, dest, sizeof dest);
     {   /* copy it in, unless it is already the file we would write */
         FILE *in = psx_fopen_utf8(png_path, "rb");
         if (!in) { if (msg && cap) snprintf(msg, cap, "Could not read that file"); return 0; }
@@ -559,6 +576,17 @@ int psx_cpu_portrait_set(int duelist, const char *png_path, char *msg, unsigned 
         }
         fclose(in);
     }
+    /* Arm the raw VRAM injector on this same folder (a no-op if it already
+     * is) and ask it to re-read its files, the same reasoning as
+     * psx_card_manager.c's install_pick(): without this the injector would
+     * not know this file exists until something else triggered a rescan,
+     * and the Free Duel select screen would keep drawing stock in the
+     * meantime even though portraits_install() (just below) already has the
+     * picture. */
+    char root[1024];
+    texpack_active_dir(root, sizeof root);
+    texpack_set_active_dir(root);
+    texpack_request_reload();
     g_edit[duelist].portrait_set = 1;
     const int painted = portraits_install();
     g_gen++;
@@ -575,6 +603,10 @@ int psx_cpu_portrait_clear(int duelist)
     psx_cpu_ensure_loaded();
     if (duelist < 0 || duelist >= NDUEL || !g_edit[duelist].portrait_set) return 0;
     char png[1200], dir[1024];
+    /* Both possible locations: "restore stock" means stock everywhere, not
+     * stock in the legacy folder while a shared-pack upload keeps drawing. */
+    portrait_png_shared(duelist, png, sizeof png);
+    (void)psx_remove_utf8(png);
     portrait_png(duelist, png, sizeof png);
     (void)psx_remove_utf8(png);
     portrait_dir(duelist, dir, sizeof dir);
@@ -893,8 +925,9 @@ void psx_cpu_ensure_loaded(void)
     ini_path(g_ini_path, sizeof g_ini_path);
     for (int d = 0; d < NDUEL; d++) {
         char png[1200];
-        portrait_png(d, png, sizeof png);
-        g_edit[d].portrait_set = (uint8_t)file_exists(png);
+        portrait_path_resolve(d, png, sizeof png);
+        s_portrait_mtime[d] = file_mtime(png);
+        g_edit[d].portrait_set = (uint8_t)(s_portrait_mtime[d] != 0);
     }
     const int n = read_ini(g_ini_path);
     snprintf(g_status, sizeof g_status, n < 0 ? "no ini" : "%d entries from ini", n < 0 ? 0 : n);
@@ -1026,7 +1059,7 @@ int psx_cpu_export_file(const char *path, char *msg, unsigned cap)
     int packed = 0;
     for (int d = 0; ok && d < NDUEL; d++) {
         if (!g_edit[d].portrait_set) continue;
-        char png[1200]; portrait_png(d, png, sizeof png);
+        char png[1200]; portrait_path_resolve(d, png, sizeof png);
         long sz = 0; unsigned char *b = psx_zip_read_file(png, &sz);
         if (!b) continue;                      /* the PNG went missing: the ini still travels */
         char name[64]; snprintf(name, sizeof name, "duelists/%d/portrait.png", d + 1);
@@ -1052,15 +1085,6 @@ static int portrait_entry(const char *name)
     while (*q >= '0' && *q <= '9') id = id * 10 + (*q++ - '0');
     if (id < 1 || id > NDUEL || strcmp(q, "/portrait.png")) return -1;
     return id - 1;
-}
-
-static void ensure_dir(const char *d)
-{
-#ifdef _WIN32
-    (void)_mkdir(d);
-#else
-    (void)mkdir(d, 0755);
-#endif
 }
 
 int psx_cpu_import_file(const char *path, char *msg, unsigned cap)
@@ -1111,20 +1135,13 @@ int psx_cpu_import_file(const char *path, char *msg, unsigned cap)
         /* the portraits: the file's replace the player's, and the ones it
          * does not carry go, the same way its ini replaces every edit */
         uint8_t in_file[NDUEL]; memset(in_file, 0, sizeof in_file);
-        char base[1100];
-        {
-            const char *pd = psx_mod_player_data_dir();
-            snprintf(base, sizeof base, "%s/duelists", pd && pd[0] ? pd : ".");
-        }
-        ensure_dir(base);
         for (int i = 0; i < k; i++) {
             const int d = portrait_entry(ents[i].name);
             if (d < 0) continue;
             long sz = 0; unsigned char *px = psx_zip_extract(b, n, &ents[i], &sz);
             if (!px) { bad++; continue; }
-            char ddir[1024], png[1200];
-            portrait_dir(d, ddir, sizeof ddir); ensure_dir(ddir);
-            portrait_png(d, png, sizeof png);
+            char png[1200];
+            portrait_path_dest(d, png, sizeof png);   /* the shared folder, same as a Change portrait pick */
             FILE *f = psx_fopen_utf8(png, "wb");
             const int ok = f && fwrite(px, 1, (size_t)sz, f) == (size_t)sz;
             if (f) fclose(f);
@@ -1133,11 +1150,17 @@ int psx_cpu_import_file(const char *path, char *msg, unsigned cap)
             in_file[d] = 1; portraits_in++;
         }
         free(b);
+        if (portraits_in) {
+            char root[1024];
+            texpack_active_dir(root, sizeof root);
+            texpack_set_active_dir(root);
+            texpack_request_reload();
+        }
         for (int d = 0; d < NDUEL; d++) {
             if (in_file[d]) { g_edit[d].portrait_set = 1; continue; }
             if (!g_edit[d].portrait_set) continue;
-            char png[1200]; portrait_png(d, png, sizeof png);
-            (void)psx_remove_utf8(png);
+            char png[1200];
+            portrait_png_shared(d, png, sizeof png); (void)psx_remove_utf8(png);
             g_edit[d].portrait_set = 0;
             psx_duelist_portraits_override(d, NULL);
         }
@@ -1183,8 +1206,27 @@ static void tick(void)
     if (psx_ygo_netplay_session()) return;   /* netplay: per-machine layer, peers must stay bit-identical */
     static unsigned seen_gen;
     static int seen_ai_ready;
+    static unsigned frames;
     if (!psx_mod_game_started()) return;
     psx_cpu_ensure_loaded();
+    /* Hot reload: a portrait dropped in, replaced, or uploaded through the
+     * Asset Manager (which does not go through psx_cpu_portrait_set) while
+     * this session is already running -- once a second, not every frame.
+     * Without this the CPU Manager only ever saw a portrait that existed at
+     * the moment psx_cpu_ensure_loaded() first ran. */
+    if ((++frames % 60u) == 0u) {
+        int changed = 0;
+        for (int d = 0; d < NDUEL; d++) {
+            char png[1200];
+            portrait_path_resolve(d, png, sizeof png);
+            const long mt = file_mtime(png);
+            if (mt == s_portrait_mtime[d]) continue;
+            s_portrait_mtime[d] = mt;
+            g_edit[d].portrait_set = (uint8_t)(mt != 0);
+            changed = 1;
+        }
+        if (changed) { (void)portraits_install(); g_gen++; }
+    }
     ai_snapshot();
     names_apply();        /* every frame: the table comes back stock with the EXE data */
     if (g_gen == seen_gen && g_ai_stock_ready == seen_ai_ready) return;

--- a/src/psx_texture_export.c
+++ b/src/psx_texture_export.c
@@ -1,0 +1,736 @@
+/* psx_texture_export.c -- write this disc's stock art into a texture pack, so
+ * there is something to paint over.
+ *
+ * This is the other half of psx_wa_catalog.c. That file hashes each asset and
+ * registers it under a name; this one decodes the same asset and writes it to
+ * a PNG under that same name, both driven by the one table in
+ * psx_wa_catalog.h. Extractor and injector therefore cannot disagree about
+ * what anything is called -- which they otherwise would, silently, and the
+ * only symptom would be art that never appears.
+ *
+ * IT NEVER OVERWRITES THE PLAYER'S ART
+ * -------------------------------------
+ * The whole point of the folder is that the player replaces its contents with
+ * HD art, so an exporter that clobbered what it found would destroy exactly
+ * the work it exists to enable. An upscale is therefore never touched.
+ *
+ * Its OWN previous output is another matter. A file at exactly the stock size
+ * is one of these exports, not a replacement -- painting over art at 1x would
+ * be invisible, so nobody does it -- and refreshing those is what makes a fix
+ * to the export actually reach the player. Otherwise every improvement to what
+ * comes out of here is skipped in silence and the player upscales a stale
+ * file. Re-running is safe, and is how you both top up new assets and pick up
+ * corrections to old ones.
+ *
+ * ON DEMAND, NOT A FRAME HOOK
+ * -----------------------------
+ * psx_texture_export_one() decodes and writes exactly one asset, synchronously,
+ * when its caller asks -- psx_asset_manager.c's Export/Export All buttons are
+ * the only callers, and Export All spreads its own ~2700 calls one asset (or
+ * a handful) per frame from ITS OWN tick(), the same "don't freeze the game"
+ * reasoning this file used to apply itself via an automatic "Mods > Export
+ * stock textures" background walker. That walker is gone: driving this from
+ * the Asset Manager makes it explicit and on-demand instead of a standing
+ * frame hook nothing outside the Asset Manager needs.
+ *
+ * PNG, WITHOUT A COMPRESSOR
+ * --------------------------
+ * The IDAT is a zlib stream of STORED (uncompressed) deflate blocks. That is a
+ * real PNG every viewer and editor accepts, and it needs nothing linked in.
+ * The files are bigger than a compressed PNG -- about 40 KB for a card
+ * portrait -- which is irrelevant for something the player is about to replace
+ * anyway, and cheaper than taking a dependency for it.
+ */
+
+#include "psx_texture_export.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#  include <direct.h>
+#  define TX_MKDIR(p) _mkdir(p)
+#else
+#  include <unistd.h>
+#  define TX_MKDIR(p) mkdir((p), 0755)
+#endif
+
+#include "psx_wa_catalog.h"
+#include "texture_pack.h"
+
+#define PATH_MAX_   1024
+/* The largest image in the catalog, in TEXELS: the 256x768 UI sheet. The
+ * RGBA scratch below is 768 KB of static storage -- big, but paid once and
+ * dwarfed by the 1 MB guest VRAM this runtime already carries. */
+#define PIXELS_MAX  (256 * 768)
+/* One texture page's worth of rows -- the unit the game uploads and palettises
+ * tall art in, so also the unit this exports it in. Must match the band size
+ * psx_wa_catalog.c registers with. */
+#define PAGE_ROWS   256
+
+static unsigned s_written, s_skipped, s_failed;
+
+/* ---- PNG ------------------------------------------------------------------ */
+static uint32_t crc_table(uint32_t c)
+{
+    for (int k = 0; k < 8; k++)
+        c = (c >> 1) ^ (0xEDB88320u & (uint32_t)(-(int)(c & 1)));
+    return c;
+}
+
+static uint32_t crc32_run(uint32_t crc, const uint8_t *p, size_t n)
+{
+    while (n--)
+        crc = crc_table((crc ^ *p++) & 0xFF) ^ (crc >> 8);
+    return crc;
+}
+
+static uint32_t adler32_run(const uint8_t *p, size_t n)
+{
+    uint32_t a = 1, b = 0;
+    while (n--) {
+        a += *p++; if (a >= 65521u) a -= 65521u;
+        b += a;    if (b >= 65521u) b -= 65521u;
+    }
+    return (b << 16) | a;
+}
+
+static void be32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);  p[3] = (uint8_t)v;
+}
+
+static int chunk(FILE *f, const char *type, const uint8_t *data, uint32_t len)
+{
+    uint8_t hdr[4];
+    be32(hdr, len);
+    if (fwrite(hdr, 1, 4, f) != 4) return 0;
+    if (fwrite(type, 1, 4, f) != 4) return 0;
+    if (len && fwrite(data, 1, len, f) != len) return 0;
+    uint32_t crc = crc32_run(0xFFFFFFFFu, (const uint8_t *)type, 4);
+    if (len) crc = crc32_run(crc, data, len);
+    be32(hdr, crc ^ 0xFFFFFFFFu);
+    return fwrite(hdr, 1, 4, f) == 4;
+}
+
+static int write_png_rgba(const char *path, const uint8_t *rgba, int w, int h)
+{
+    static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    const size_t row = 1u + (size_t)w * 4u;
+    const size_t raw_len = row * (size_t)h;
+
+    uint8_t *raw = (uint8_t *)malloc(raw_len);
+    if (!raw) return 0;
+    for (int y = 0; y < h; y++) {
+        raw[(size_t)y * row] = 0;                 /* filter: none */
+        memcpy(raw + (size_t)y * row + 1,
+               rgba + (size_t)y * (size_t)w * 4u, (size_t)w * 4u);
+    }
+
+    const size_t blocks = (raw_len + 65534u) / 65535u;
+    uint8_t *z = (uint8_t *)malloc(2u + raw_len + blocks * 5u + 4u);
+    if (!z) { free(raw); return 0; }
+
+    size_t p = 0, off = 0, left = raw_len;
+    z[p++] = 0x78; z[p++] = 0x01;                 /* zlib header */
+    while (left) {
+        const unsigned n = (unsigned)(left > 65535u ? 65535u : left);
+        z[p++] = (uint8_t)(left <= 65535u);       /* BFINAL, stored */
+        z[p++] = (uint8_t)n;        z[p++] = (uint8_t)(n >> 8);
+        z[p++] = (uint8_t)(~n);     z[p++] = (uint8_t)((~n) >> 8);
+        memcpy(z + p, raw + off, n);
+        p += n; off += n; left -= n;
+    }
+    be32(z + p, adler32_run(raw, raw_len)); p += 4;
+
+    FILE *f = fopen(path, "wb");
+    if (!f) { free(z); free(raw); return 0; }
+
+    uint8_t ihdr[13];
+    be32(ihdr + 0, (uint32_t)w);
+    be32(ihdr + 4, (uint32_t)h);
+    ihdr[8] = 8;    /* 8 bits per channel */
+    ihdr[9] = 6;    /* RGBA */
+    ihdr[10] = ihdr[11] = ihdr[12] = 0;
+
+    int ok = fwrite(sig, 1, 8, f) == 8 &&
+             chunk(f, "IHDR", ihdr, sizeof ihdr) &&
+             chunk(f, "IDAT", z, (uint32_t)p) &&
+             chunk(f, "IEND", NULL, 0);
+
+    fclose(f);
+    free(z);
+    free(raw);
+    return ok;
+}
+
+/* ---- paths ---------------------------------------------------------------- */
+static int exists(const char *path)
+{
+    struct stat st;
+    return stat(path, &st) == 0;
+}
+
+/* mkdir -p, in place, on a path that uses '/'. */
+static void mkdir_p(char *path)
+{
+    for (char *p = path + 1; *p; p++) {
+        if (*p != '/') continue;
+        *p = '\0';
+        TX_MKDIR(path);
+        *p = '/';
+    }
+    TX_MKDIR(path);
+}
+
+/* The ACTIVE pack's real folder, not a hardcoded name -- texpack_active_dir()
+ * (texture_pack.h), the one place every window that reads or writes a pack's
+ * files resolves this. This used to reimplement the same fallback locally,
+ * which is exactly how the Asset Manager and this exporter could once have
+ * quietly agreed on two different folders for a second, or differently
+ * named, pack; card art and CPU portraits share this same folder now too
+ * (psx_card_packs.c, psx_cpu_data.c), so one definition covers all of them. */
+static int pack_root(char *out, size_t cap)
+{
+    texpack_active_dir(out, (unsigned)cap);
+    return out[0] != 0;
+}
+
+/* One PNG per ELEMENT, cropped to a rectangle the game actually draws.
+ *
+ * A UI page is a dense sheet with no blank rows, so every way of cutting it
+ * into files is arbitrary -- and the cuts I chose put icons in with labels.
+ * The game's draws are not arbitrary: each samples exactly one element, so
+ * those rectangles are the real boundaries. Named for the rectangle so the
+ * injector can find one from a draw without a lookup table.
+ *
+ * These are cut from the page image that was just written, so they inherit its
+ * per-region palettes and are correct wherever it is. Never overwritten: once
+ * a file exists it is the player's to paint. */
+/* Reassemble the sheet the way the SCREEN shows it.
+ *
+ * A UI sheet is stored as scattered pieces and drawn as a picture: the
+ * dialogue box's frame line and its hazard-stripe header are each built from
+ * several quads out of one sheet. Painting that in sheet layout means
+ * painting a jigsaw. So every drawn region is copied to where it actually
+ * lands, and regions whose destinations touch are assembled into one canvas
+ * -- typically one canvas per thing you can point at on screen.
+ *
+ * A .map file beside each canvas records piece -> placement, so
+ * tools/slice_screen.py can cut a painted canvas back into the per-element
+ * files the injector already understands. Assembly here, injection
+ * unchanged -- this is purely an authoring convenience.
+ *
+ * Pieces the game scales are skipped: their source and destination differ in
+ * size, so pasting one would distort it. */
+/* A multi-region canvas is named by WHERE it landed on screen (screen_X_Y),
+ * because that is the only thing known about it in general -- two different
+ * screens sharing one asset produce two different, un-guessable positions.
+ * But for the handful the disc has already been checked against, the size is
+ * a stable fingerprint (a given picture is always the same number of pixels,
+ * regardless of which savestate or session captured it), so those get a name
+ * a pack author can actually recognise instead of coordinates. Anything not
+ * listed here -- including Konami's two screens, not yet captured live at
+ * the time this table was written -- keeps the coordinate name; add a row
+ * once its canvas size is confirmed by decoding it and looking, the same bar
+ * every entry in psx_wa_catalog.c's own table has to clear. */
+static const struct { const char *asset; int w, h; const char *label; } SCREEN_NAMES[] = {
+    { "ui/logo/front",         321, 169, "logo" },
+    { "ui/logo/front",         233,  17, "press_start" },
+    { "free_duel/background",  321, 241, "background" },
+};
+#define SCREEN_NAME_N ((int)(sizeof SCREEN_NAMES / sizeof SCREEN_NAMES[0]))
+
+static const char *screen_label(const char *name, int w, int h)
+{
+    for (int i = 0; i < SCREEN_NAME_N; i++)
+        if (!strcmp(SCREEN_NAMES[i].asset, name) &&
+            SCREEN_NAMES[i].w == w && SCREEN_NAMES[i].h == h)
+            return SCREEN_NAMES[i].label;
+    return NULL;
+}
+
+static void write_screens(const char *root, const char *name,
+                          const PsxWaAsset *a, int index, int dw, int dh)
+{
+    if (dw != a->w || dh != a->h)
+        return;
+
+    const int entries = (a->bpp == 4) ? 16 : 256;
+    const int nr = texpack_clut_rect_count(name);
+    if (nr <= 0)
+        return;
+
+    /* Wide enough for an 8bpp palette: some UI sheets are 256-entry. */
+#define SCR_MAX 256
+    static int grp[SCR_MAX];
+    static int sx0[SCR_MAX], sy0[SCR_MAX], sx1[SCR_MAX], sy1[SCR_MAX];
+    static int dx0[SCR_MAX], dy0[SCR_MAX], dx1[SCR_MAX], dy1[SCR_MAX];
+    static uint16_t pals[SCR_MAX][256];
+    int n = 0;
+
+    for (int i = 0; i < nr && n < SCR_MAX; i++) {
+        uint16_t rp[256];
+        int a0, b0, a1, b1, c0, e0, c1, e1;
+        if (!texpack_clut_rect_get(name, i, &a0, &b0, &a1, &b1, rp, entries))
+            continue;
+        if (!texpack_clut_rect_dst(name, i, &c0, &e0, &c1, &e1))
+            continue;
+        /* Reject only art the game genuinely SCALES. The two rectangles are
+         * measured differently -- lim is inclusive texel bounds, so a 32-wide
+         * piece reads 0..31, while the screen box comes from vertex positions
+         * and reads 100..132 -- so an unscaled draw differs by exactly one in
+         * each axis. Demanding equality rejected every piece the first time
+         * this was written, so no canvas was ever produced. */
+        const int sdw = (a1 - a0) - (c1 - c0), sdh = (b1 - b0) - (e1 - e0);
+        if (sdw < -1 || sdw > 1 || sdh < -1 || sdh > 1)
+            continue;
+        sx0[n]=a0; sy0[n]=b0; sx1[n]=a1; sy1[n]=b1;
+        dx0[n]=c0; dy0[n]=e0; dx1[n]=c1; dy1[n]=e1;
+        memcpy(pals[n], rp, (size_t)entries * 2u);
+        grp[n] = n;
+        n++;
+    }
+    if (!n)
+        return;
+
+    /* Group by destination adjacency: pieces of one picture touch or tile
+     * end to end. Scattered SOURCE positions alone prove nothing -- a frame's
+     * border segments or an icon strip can legitimately be sourced from all
+     * over the sheet -- so source position is not checked for an ordinary
+     * touch/tile.
+     *
+     * But when two pieces' destinations actually OVERLAP in pixels (not just
+     * sit within the gap), tiling is not what is happening: real composite
+     * art tiles its parts edge to edge, it does not draw one part over
+     * another. An overlap paired with sources nowhere near each other on the
+     * sheet is the signature of two UNRELATED elements the game simply drew
+     * at overlapping screen positions (a duel-HUD icon and a number badge,
+     * say) -- merging those pastes fragments of one over the other. Require
+     * the sources to be plausibly related, too, before allowing that merge;
+     * an ordinary non-overlapping touch is unaffected. */
+    for (int pass = 0; pass < n; pass++)
+        for (int i = 0; i < n; i++)
+            for (int j = i + 1; j < n; j++) {
+                if (grp[i] == grp[j]) continue;
+                const int gap = 4;
+                if (!(dx0[i] - gap <= dx1[j] && dx0[j] - gap <= dx1[i] &&
+                      dy0[i] - gap <= dy1[j] && dy0[j] - gap <= dy1[i]))
+                    continue;
+                const int dst_overlaps =
+                    dx0[i] <= dx1[j] && dx0[j] <= dx1[i] &&
+                    dy0[i] <= dy1[j] && dy0[j] <= dy1[i];
+                if (dst_overlaps) {
+                    const int src_gap = 24;
+                    const int src_near =
+                        sx0[i] - src_gap <= sx1[j] && sx0[j] - src_gap <= sx1[i] &&
+                        sy0[i] - src_gap <= sy1[j] && sy0[j] - src_gap <= sy1[i];
+                    if (!src_near)
+                        continue;   /* overlaps on screen, unrelated on the sheet */
+                }
+                const int lo = grp[i] < grp[j] ? grp[i] : grp[j];
+                const int hi = grp[i] < grp[j] ? grp[j] : grp[i];
+                for (int k = 0; k < n; k++) if (grp[k] == hi) grp[k] = lo;
+            }
+
+    static uint8_t whole[PIXELS_MAX * 4];
+    static uint8_t canvas[PIXELS_MAX * 4];
+
+    for (int g = 0; g < n; g++) {
+        int members = 0, X0 = 0, Y0 = 0, X1 = 0, Y1 = 0;
+        for (int i = 0; i < n; i++) {
+            if (grp[i] != g) continue;
+            if (!members) { X0=dx0[i]; Y0=dy0[i]; X1=dx1[i]; Y1=dy1[i]; }
+            else {
+                if (dx0[i] < X0) X0 = dx0[i];
+                if (dy0[i] < Y0) Y0 = dy0[i];
+                if (dx1[i] > X1) X1 = dx1[i];
+                if (dy1[i] > Y1) Y1 = dy1[i];
+            }
+            members++;
+        }
+        if (!members) continue;
+        const int cw = X1 - X0 + 1, chh = Y1 - Y0 + 1;
+        if (cw <= 0 || chh <= 0 || (size_t)cw * (size_t)chh * 4u > sizeof canvas)
+            continue;
+
+        char cp[PATH_MAX_ + 160], mp[PATH_MAX_ + 160], stem[64];
+        const char *label = screen_label(name, cw, chh);
+        if (label)
+            snprintf(stem, sizeof stem, "%s", label);
+        else
+            snprintf(stem, sizeof stem, "screen_%d_%d", X0, Y0);
+        if (snprintf(cp, sizeof cp, "%s/%s/%s.png", root, name, stem) >= (int)sizeof cp)
+            continue;
+        snprintf(mp, sizeof mp, "%s/%s/%s.map", root, name, stem);
+        if (exists(cp))
+            continue;
+
+        memset(canvas, 0, (size_t)cw * (size_t)chh * 4u);
+        FILE *mf = fopen(mp, "wb");
+        if (mf)
+            fprintf(mf, "# canvas %dx%d at screen %d,%d of %s\n"
+                        "# src_x src_y w h  canvas_x canvas_y  cluthash\n",
+                    cw, chh, X0, Y0, name);
+
+        for (int i = 0; i < n; i++) {
+            if (grp[i] != g) continue;
+            if (!psx_wa_catalog_decode_pal(a, index, whole, pals[i], entries))
+                continue;
+            const int w = sx1[i] - sx0[i] + 1, h = sy1[i] - sy0[i] + 1;
+            for (int y = 0; y < h; y++) {
+                const uint8_t *sp = whole + ((size_t)(sy0[i] + y) * dw + sx0[i]) * 4u;
+                uint8_t *cq = canvas + ((size_t)(dy0[i] - Y0 + y) * cw
+                                        + (dx0[i] - X0)) * 4u;
+                for (int x = 0; x < w; x++)
+                    if (sp[x * 4 + 3])          /* layered: keep what is there */
+                        memcpy(cq + x * 4, sp + x * 4, 4);
+            }
+            uint64_t ph[2];
+            texpack_hash128(pals[i], (unsigned)entries * 2u, ph);
+            if (mf)
+                fprintf(mf, "%d %d %d %d  %d %d  %016llx%016llx\n",
+                        sx0[i], sy0[i], w, h, dx0[i] - X0, dy0[i] - Y0,
+                        (unsigned long long)ph[0], (unsigned long long)ph[1]);
+        }
+        if (mf) fclose(mf);
+
+        char dir[PATH_MAX_ + 160];
+        snprintf(dir, sizeof dir, "%s", cp);
+        char *slash = strrchr(dir, '/');
+        if (slash) { *slash = '\0'; mkdir_p(dir); }
+        if (write_png_rgba(cp, canvas, cw, chh)) s_written++;
+        else                                     s_failed++;
+    }
+}
+
+static void write_elements(const char *root, const char *name,
+                           const PsxWaAsset *a, int index, int dw, int dh)
+{
+    if (dw != a->w || dh != a->h)
+        return;                 /* retiled art: image coords are not page ones */
+
+    const int entries = (a->bpp == 4) ? 16 : 256;
+    const int nr = texpack_clut_rect_count(name);
+    static uint8_t crop[PIXELS_MAX * 4];
+
+    for (int i = 0; i < nr; i++) {
+        uint16_t rp[256];
+        int x0, y0, x1, y1;
+        if (!texpack_clut_rect_get(name, i, &x0, &y0, &x1, &y1, rp, entries))
+            continue;
+        if (x0 < 0) x0 = 0;
+        if (y0 < 0) y0 = 0;
+        if (x1 >= dw) x1 = dw - 1;
+        if (y1 >= dh) y1 = dh - 1;
+        const int w = x1 - x0 + 1, h = y1 - y0 + 1;
+        if (w <= 0 || h <= 0 || (size_t)w * (size_t)h * 4u > sizeof crop)
+            continue;
+
+        /* The palette is part of the identity, not something to choose
+         * between. The same rectangle is drawn through more than one CLUT --
+         * the Konami wordmark once in black and again as part of a white wash
+         * -- and every rule I tried for picking "the real one" (newest, most
+         * varied, highest contrast) got some case wrong. So both are exported,
+         * named by their palette, and the injector picks by the CLUT the draw
+         * actually uses. No guessing, and nothing lost. */
+        uint64_t ph[2];
+        texpack_hash128(rp, (unsigned)entries * 2u, ph);
+        char ep[PATH_MAX_ + 160];
+        if (snprintf(ep, sizeof ep, "%s/%s/%d_%d_%dx%d@%016llx%016llx.png",
+                     root, name, x0, y0, w, h,
+                     (unsigned long long)ph[0], (unsigned long long)ph[1])
+                >= (int)sizeof ep)
+            continue;
+        if (exists(ep))
+            continue;
+
+        /* Decoded through this region's own palette rather than cut from the
+         * composed page: the page can only show one of the colourings. */
+        static uint8_t whole[PIXELS_MAX * 4];
+        if (!psx_wa_catalog_decode_pal(a, index, whole, rp, entries))
+            continue;
+        for (int y = 0; y < h; y++)
+            memcpy(crop + (size_t)y * w * 4u,
+                   whole + ((size_t)(y0 + y) * dw + x0) * 4u,
+                   (size_t)w * 4u);
+
+        char dir[PATH_MAX_ + 160];
+        snprintf(dir, sizeof dir, "%s", ep);
+        char *slash = strrchr(dir, '/');
+        if (slash) { *slash = '\0'; mkdir_p(dir); }
+        if (write_png_rgba(ep, crop, w, h)) s_written++;
+        else                                s_failed++;
+    }
+}
+
+/* ---- one asset ------------------------------------------------------------ */
+/* See psx_texture_export_one() (the public wrapper right below) for the
+ * return-value contract; `root` is the caller's chosen destination, not
+ * necessarily the active pack's own folder. */
+static int export_one(const PsxWaAsset *a, int index, const char *root)
+{
+    char path[PATH_MAX_ + 128], name[96];
+
+    /* The curated path when this row has one, exactly matching what
+     * register_one() (psx_wa_catalog.c) registered it under and what the
+     * Asset Manager's own browsing tree shows -- see
+     * psx_wa_catalog_display_path()'s header comment. Falls back to the raw
+     * disc-family name for anything not curated yet, same as registration. */
+    if (!psx_wa_catalog_display_path(a, index, name, sizeof name))
+        snprintf(name, sizeof name, a->name_fmt, a->first + index);
+    if (snprintf(path, sizeof path, "%s/%s.png", root, name) >= (int)sizeof path) {
+        s_failed++;
+        return 0;
+    }
+
+    int dw, dh;
+    psx_wa_catalog_disp_size(a, index, &dw, &dh);
+
+    /* UI art is DUMPED, not reconstructed.
+     *
+     * A UI sheet's identity is pixels TIMES palette: the same bytes are the
+     * black wordmark under one CLUT and the white wash under another, and
+     * every attempt to compose "the" sheet out of that -- observed palettes,
+     * dominant-coverage fallbacks, contrast heuristics, region repaints,
+     * hole-filling -- guessed wrongly for some screen, because the game means
+     * all of its colourings at once. So for UI art this writes one file per
+     * element per palette, each pixel-for-pixel what a draw actually showed
+     * (write_elements), and no whole-sheet file at all. What lands on disk is
+     * what was on screen; there is nothing left to infer.
+     *
+     * The explicitly tinted sheets (the font) skip BOTH and keep only the
+     * whole-page export: their workflow is a single alpha mask painted over
+     * the full sheet, and that canvas has one honest colouring by
+     * construction, precisely because it carries no baked colour of its own.
+     * An element or assembled-screen file draws FLAT the moment its exact
+     * palette recurs -- correct for art with one true colouring, but it
+     * would let a single painted glyph freeze to one colour forever, which
+     * is the opposite of what tinting the font buys: dialogue white, a card
+     * name in whatever colour its type gives it, from the one file.
+     *
+     * tint == -1 ALSO skips this, same as tint == 1, and for a different
+     * reason: -1 means "never tinted, single fixed colouring" (dialog_frame,
+     * the boot logo's hieroglyph layer, ui/panels) -- art with exactly ONE
+     * true palette, just not yet a known one. That is not the "pixels times
+     * palette" ambiguity this branch exists for; it is the same shape as a
+     * card or a background, and belongs on the plain path below with them.
+     * The condition used to be `tint != 1`, which caught tint == -1 too and
+     * multi-region-dumped these into scattered per-rectangle files with no
+     * single picture to look at or paint -- correct only for genuinely
+     * multi-palette UI (duel_labels, the menu labels, guardian-star-turned-
+     * monster-type icons, card_sleeves/canvas), which all default to
+     * tint == 0 and are unaffected by this narrowing. */
+    if (psx_wa_catalog_ui(a) && a->tint == 0) {
+        write_elements(root, name, a, index, dw, dh);
+        /* write_screens() (the assembled screen_X_Y.png + .map convenience
+         * canvas) is no longer called here -- nothing in the runtime ever
+         * read it, and the individual rect@hash.png files write_elements()
+         * just wrote above are the exact same content the injector actually
+         * resolves. Disabled per explicit request rather than left running
+         * to produce files nobody consumes; the function itself is kept
+         * (see its own header) in case the paint-a-whole-canvas authoring
+         * workflow is wanted back, at which point tools/slice_screen.py
+         * still knows how to cut its output apart. */
+        /* Nothing captured yet, but the table might still know a real disc
+         * colouring anyway -- some multi-context sheets (the menu labels) do
+         * have one confirmed default palette even though other rows/states
+         * genuinely need live capture. This is a REFERENCE only, named so it
+         * can never satisfy the runtime's exact-match replacement lookup
+         * (a plain "<name>.png" at the pack root, or a "rect@hash.png"
+         * element) -- it exists purely so a pack author opens an empty
+         * folder and sees real colours to paint from instead of nothing. */
+        if (texpack_clut_rect_count(name) == 0 && a->clut_entries > 0 &&
+            a->ref_whole && dw == a->w && dh == a->h) {
+            char rp[PATH_MAX_ + 160];
+            if (snprintf(rp, sizeof rp, "%s/%s/_reference.png", root, name)
+                    < (int)sizeof rp && !exists(rp)) {
+                static uint8_t ref[PIXELS_MAX * 4];
+                if (psx_wa_catalog_decode(a, index, ref)) {
+                    char dir[PATH_MAX_ + 160];
+                    snprintf(dir, sizeof dir, "%s", rp);
+                    char *slash = strrchr(dir, '/');
+                    if (slash) { *slash = '\0'; mkdir_p(dir); }
+                    (void)write_png_rgba(rp, ref, dw, dh);
+                }
+            }
+        }
+        /* A sheet can be PARTIALLY captured -- some regions genuinely seen
+         * and correctly coloured, others (a different screen's furniture on
+         * the same page, never visited this session) still blank -- and
+         * until now a partial sheet got nothing for the blank part: the
+         * block above only fires when NO region has been captured, so one
+         * captured corner silenced the reference for the whole rest of the
+         * sheet. ui/panels is the concrete case: the Deck screen's CHEST/
+         * ORDER/DECK furniture captures fine, but the in-duel LP boxes live
+         * on rows the Deck screen never draws, so they stayed permanently
+         * invisible even though the disc bytes for them are right there.
+         *
+         * This is what psx_wa_catalog_decode_rows() ALREADY does when a
+         * catalog entry has no known palette (ui/panels: clut_entries == 0)
+         * -- render the index value as a grey ramp instead of inventing a
+         * colour. That is safe to always emit, unlike the coloured
+         * reference above: a grey ramp can never be confidently WRONG the
+         * way a borrowed palette can (the exact "looks complete, quietly
+         * wrong" failure ref_whole exists to prevent), so it does not need
+         * ref_whole's human-verified opt-in, and unlike the coloured
+         * reference it is not silenced by other regions already being
+         * captured -- a pack author can see the shape of every uncaptured
+         * piece, not just the ones on an empty sheet. */
+        /* Extended (2026-09-11) to fire for clut_entries > 0 sheets too, not
+         * just clut_entries == 0 -- duel_labels/duel_panels/monster_types all
+         * have a real (16-entry) table palette, so they never qualified for
+         * this grey fallback before, and any of them whose anchor never
+         * validates live (ui/icons/monster_types: permanently blocked by a
+         * VRAM reuse collision every session so far) got nothing at all: no
+         * coloured reference (needs ref_whole, which is unset -- duel_labels'
+         * own comment says outright that ONE static palette is wrong for at
+         * least one of its two contexts, so setting it there would be
+         * exactly the "looks complete, quietly wrong" mistake ref_whole
+         * exists to prevent), and no grey one either (gated to
+         * clut_entries == 0 only, until now).
+         *
+         * Pulls raw indices (psx_wa_catalog_indices), not decode_pal/
+         * decode_rows: those two read the table's OWN clut_off palette
+         * automatically whenever clut_entries > 0, which would silently
+         * reintroduce the exact "confidently wrong colour" problem this
+         * block exists to avoid for sheets ref_whole is correctly withheld
+         * from -- the whole point is index-only structure, regardless of
+         * whether a (possibly wrong-for-this-region) table palette exists. */
+        if (dw == a->w && dh == a->h) {
+            char rp[PATH_MAX_ + 160];
+            if (snprintf(rp, sizeof rp, "%s/%s/_reference.png", root, name)
+                    < (int)sizeof rp && !exists(rp)) {
+                static uint8_t idx[PIXELS_MAX];
+                static uint8_t ref[PIXELS_MAX * 4];
+                const uint32_t npix = (uint32_t)dw * (uint32_t)dh;
+                if (npix <= sizeof idx &&
+                    psx_wa_catalog_indices(a, index, idx, sizeof idx)) {
+                    const int max_idx = (a->bpp == 4) ? 15 : 255;
+                    for (uint32_t i = 0; i < npix; i++) {
+                        uint8_t *q = ref + (size_t)i * 4u;
+                        const uint8_t g = (uint8_t)((int)idx[i] * 255 / max_idx);
+                        q[0] = q[1] = q[2] = g;
+                        q[3] = idx[i] ? 255 : 0;
+                    }
+                    char dir[PATH_MAX_ + 160];
+                    snprintf(dir, sizeof dir, "%s", rp);
+                    char *slash = strrchr(dir, '/');
+                    if (slash) { *slash = '\0'; mkdir_p(dir); }
+                    (void)write_png_rgba(rp, ref, dw, dh);
+                }
+            }
+        }
+        return 1;
+    }
+
+    /* Never overwrite: an existing file is the player's, whatever its size. */
+    if (exists(path)) { s_skipped++; return 1; }
+
+    /* TINTED art (the font: tint == 1, never caught by the tint == 0 UI
+     * branch above since that returned already) is a WHITE MASK on
+     * transparency by design -- see psx_wa_catalog.h's "WHEN TO SET tint".
+     * The colour the game shows it in comes from the CLUT the renderer swaps
+     * in per draw, never from this file. Nothing below this point ever
+     * checked psx_wa_catalog_tinted(a): the table's own disc palette (font
+     * has a real one, clut_entries == 16) was being decoded and baked in
+     * unconditionally, so the export came out whatever colour the disc
+     * happens to store the glyphs in -- red, here -- instead of neutral
+     * white.
+     *
+     * Alpha comes from the INDEX VALUE itself, not a binary in/out test: a
+     * PS1 font's index levels ARE its anti-aliasing (0 transparent, 15/255
+     * fully opaque, everything between a soft edge) -- collapsing that to a
+     * hard on/off mask would throw the edge smoothing away and hand a pack
+     * author jagged glyphs to repaint from. Scaled to the bpp's real index
+     * range so a 4bpp sheet's 0-15 and an 8bpp sheet's 0-255 both reach full
+     * opacity, not just 4bpp topping out at 15/255. */
+    if (psx_wa_catalog_tinted(a)) {
+        static uint8_t idx[PIXELS_MAX];
+        static uint8_t mask[PIXELS_MAX * 4];
+        const uint32_t npix = (uint32_t)dw * (uint32_t)dh;
+        if (npix > sizeof idx || (size_t)npix * 4u > sizeof mask ||
+            !psx_wa_catalog_indices(a, index, idx, sizeof idx)) {
+            s_failed++;
+            return 0;
+        }
+        const int max_idx = (a->bpp == 4) ? 15 : 255;
+        for (uint32_t i = 0; i < npix; i++) {
+            uint8_t *q = mask + (size_t)i * 4u;
+            const uint8_t alpha = (uint8_t)((int)idx[i] * 255 / max_idx);
+            q[0] = q[1] = q[2] = 255;
+            q[3] = alpha;
+        }
+        char dir[PATH_MAX_ + 128];
+        snprintf(dir, sizeof dir, "%s", path);
+        char *slash = strrchr(dir, '/');
+        if (slash) { *slash = '\0'; mkdir_p(dir); }
+        if (write_png_rgba(path, mask, dw, dh)) { s_written++; return 1; }
+        s_failed++;
+        return 0;
+    }
+
+    /* The table's palette when it has one, else the one palette the renderer
+     * saw -- good enough for the single-colouring art that reaches here. */
+    uint16_t pal[256];
+    int pal_n = 0;
+    if (!a->clut_entries) {
+        pal_n = (a->bpp == 4) ? 16 : 256;
+        if (!texpack_observed_clut(name, pal, pal_n))
+            pal_n = 0;          /* never drawn yet: grey ramp */
+    }
+
+    static uint8_t rgba[PIXELS_MAX * 4];
+    if ((size_t)dw * (size_t)dh * 4u > sizeof rgba) {
+        s_failed++;
+        return 0;
+    }
+
+    /* Art taller than one texture page is uploaded and palettised a band at a
+     * time; backgrounds untile as a whole and are one palette by construction. */
+    const int bands = (dh == a->h) ? (a->h + PAGE_ROWS - 1) / PAGE_ROWS : 1;
+    if (bands > 1) {
+        for (int b = 0; b < bands; b++) {
+            const int row0 = b * PAGE_ROWS;
+            const int rows = (a->h - row0 < PAGE_ROWS) ? a->h - row0 : PAGE_ROWS;
+            uint16_t bp[256];
+            int bn = (a->bpp == 4) ? 16 : 256;
+            if (!texpack_observed_clut_page(name, row0, bp, bn))
+                bn = 0;
+            if (!psx_wa_catalog_decode_rows(a, index, rgba, row0, rows,
+                                            bn ? bp : (pal_n ? pal : NULL),
+                                            bn ? bn : pal_n)) {
+                s_failed++;
+                return 0;
+            }
+        }
+    } else if (!psx_wa_catalog_decode_pal(a, index, rgba,
+                                          pal_n ? pal : NULL, pal_n)) {
+        s_failed++;
+        return 0;
+    }
+
+    char dir[PATH_MAX_ + 128];
+    snprintf(dir, sizeof dir, "%s", path);
+    char *slash = strrchr(dir, '/');
+    if (slash) { *slash = '\0'; mkdir_p(dir); }
+
+    if (write_png_rgba(path, rgba, dw, dh)) { s_written++; return 1; }
+    s_failed++;
+    return 0;
+}
+
+int psx_texture_export_one(const PsxWaAsset *a, int index, const char *root)
+{
+    if (!a || !root || !*root) return 0;
+    return export_one(a, index, root);
+}
+
+int  psx_texture_export_write_png(const char *path, const uint8_t *rgba, int w, int h)
+{
+    return write_png_rgba(path, rgba, w, h);
+}
+void psx_texture_export_mkdir_p(char *path) { mkdir_p(path); }

--- a/src/psx_texture_export.h
+++ b/src/psx_texture_export.h
@@ -1,0 +1,47 @@
+/* psx_texture_export.h -- see psx_texture_export.c.
+ *
+ * Decodes this disc's stock art (or, for genuinely multi-palette UI sheets,
+ * whatever the game has drawn live this session through its own CLUT) into a
+ * PNG named exactly as psx_wa_catalog.c registers it. Replace that file with
+ * a higher-resolution version and the injector draws it instead.
+ *
+ * On demand only -- psx_asset_manager.c's Export/Export All buttons are the
+ * only callers. There used to also be an automatic "Mods > Export stock
+ * textures" action walking the whole table in the background every frame;
+ * removed in favour of driving this from the Asset Manager instead, so this
+ * file has no menu/frame-hook registration of its own to worry about.
+ *
+ * Existing files are never overwritten -- see the .c for why that is the whole
+ * point rather than a nicety. */
+#ifndef PSX_TEXTURE_EXPORT_H
+#define PSX_TEXTURE_EXPORT_H
+
+#include <stdint.h>
+#include "psx_wa_catalog.h"   /* PsxWaAsset -- an anonymous-struct typedef,
+                               * so it cannot be forward-declared; a real
+                               * include is the only option */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exports ONE catalog entry (a->name_fmt's `index`'th record) to `root` --
+ * an arbitrary caller-chosen destination, not necessarily the active pack's
+ * own folder (see psx_asset_manager.c's Export/Export All, which prompt for
+ * one each time). Returns 1 if something was written OR the file already
+ * existed and was correctly left alone (see "never overwrite" above), 0 on a
+ * real failure (bad path, decode failure, disk write failure). */
+int psx_texture_export_one(const PsxWaAsset *a, int index, const char *root);
+
+/* The exporter's own tiny PNG writer (no external zlib needed -- DEFLATE
+ * "stored" blocks) and mkdir -p, shared so a second writer of this exact file
+ * format never has to duplicate the CRC/Adler32 plumbing. `path` for mkdir_p
+ * is edited in place and restored; pass a mutable buffer. */
+int  psx_texture_export_write_png(const char *path, const uint8_t *rgba, int w, int h);
+void psx_texture_export_mkdir_p(char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PSX_TEXTURE_EXPORT_H */

--- a/src/psx_tool_window.c
+++ b/src/psx_tool_window.c
@@ -16,6 +16,7 @@
 #include "psx_fusion_manager.h"
 #include "psx_dialogue_manager.h"
 #include "psx_cpu_manager.h"
+#include "psx_asset_manager.h"
 #include "host_osd.h"
 
 static int  s_row = -1;
@@ -44,7 +45,7 @@ static EditorPerf s_editor_perf[PSX_FM_PAGE_COUNT];
 static uint64_t s_editor_switches;
 
 static const char *const s_page_names[PSX_FM_PAGE_COUNT] = {
-    "Cards", "Drop Tables", "Fusions", "Dialogue", "CPU"
+    "Cards", "Drop Tables", "Fusions", "Dialogue", "CPU", "Textures"
 };
 
 /* Keep a small horizontal gutter around a fitted window.  KWin may relocate a
@@ -110,6 +111,7 @@ static void page_close(int page)
     case PSX_FM_PAGE_FUSIONS:  psx_fusion_manager_close(); break;
     case PSX_FM_PAGE_DIALOGUE: psx_dialogue_manager_close(); break;
     case PSX_FM_PAGE_CPU:      psx_cpu_manager_close(); break;
+    case PSX_FM_PAGE_TEXTURES: psx_asset_manager_close(); break;
     default: break;
     }
 }
@@ -127,6 +129,7 @@ void psx_fm_editor_open_page(int page)
     case PSX_FM_PAGE_FUSIONS:  psx_fusion_manager_open(); break;
     case PSX_FM_PAGE_DIALOGUE: psx_dialogue_manager_open(); break;
     case PSX_FM_PAGE_CPU:      psx_cpu_manager_open(); break;
+    case PSX_FM_PAGE_TEXTURES: psx_asset_manager_open(); break;
     default: break;
     }
 }
@@ -270,7 +273,7 @@ int psx_fm_editor_filter_event(int page, const SDL_Event *event,
         const SDL_Keymod mod = event->key.keysym.mod;
 #endif
         if (event->key.windowID == id && (mod & KMOD_CTRL) &&
-            key >= SDLK_1 && key <= SDLK_5) {
+            key >= SDLK_1 && key <= SDLK_6) {
             psx_fm_editor_open_page((int)(key - SDLK_1));
             return 1;
         }
@@ -327,7 +330,7 @@ int psx_fm_editor_state_json(char *out, unsigned cap)
               y + h + top + bottom <= usable.y + usable.h;
     }
     int n = snprintf(out, cap,
-        "\"open\":%d,\"page\":%d,\"page_name\":\"%s\",\"tabs\":5,"
+        "\"open\":%d,\"page\":%d,\"page_name\":\"%s\",\"tabs\":%d,"
         "\"window_id\":%u,\"window\":[%d,%d],\"position\":[%d,%d],"
         "\"pixels\":[%d,%d],\"borders_reported\":[%d,%d,%d,%d],"
         "\"borders\":[%d,%d,%d,%d],\"borders_estimated\":%d,"
@@ -338,7 +341,7 @@ int psx_fm_editor_state_json(char *out, unsigned cap)
         "\"maximized\":%d,\"minimized\":%d,\"resizable\":%d,"
         "\"fit_count\":%u,\"last_fit\":%d",
         s_editor_win != NULL, s_editor_page,
-        s_editor_page >= 0 ? s_page_names[s_editor_page] : "",
+        s_editor_page >= 0 ? s_page_names[s_editor_page] : "", PSX_FM_PAGE_COUNT,
         s_editor_win ? (unsigned)SDL_GetWindowID(s_editor_win) : 0u,
         w, h, x, y, pw, ph,
         raw_top, raw_left, raw_bottom, raw_right,
@@ -737,7 +740,7 @@ PSX_MOD_CONSTRUCTOR(psx_tool_window_install)
         CHOICES, 2, "tool_renderer", def, NULL);
     s_editor_row = psx_video_menu_add_action(
         PSX_VM_MENU_VIEW, "FM Editor",
-        "Cards, Drop Tables, Fusions, Dialogue and CPU in one window",
+        "Cards, Drop Tables, Fusions, Dialogue, CPU and Textures in one window",
         editor_row_activate);
     (void)psx_game_add_start_hook(editor_policy);
     (void)psx_game_add_frame_hook(editor_policy);

--- a/src/psx_tool_window.h
+++ b/src/psx_tool_window.h
@@ -25,7 +25,7 @@ int psx_tool_present(SDL_Renderer *ren, SDL_Texture *tex, const void *px, int w,
 /* the configured choice right now: 0 software, 1 accelerated */
 int psx_tool_renderer_choice(void);
 
-/* One native FM Editor window shared by all five page implementations.  Each
+/* One native FM Editor window shared by all six page implementations.  Each
  * page keeps its existing renderer/canvas/backend; switching releases those
  * transient objects, retains the page's selection/edit state, and attaches
  * the next page to the same SDL_Window. */
@@ -35,6 +35,7 @@ enum {
     PSX_FM_PAGE_FUSIONS,
     PSX_FM_PAGE_DIALOGUE,
     PSX_FM_PAGE_CPU,
+    PSX_FM_PAGE_TEXTURES,
     PSX_FM_PAGE_COUNT
 };
 #define PSX_FM_EDITOR_TAB_H 38
@@ -62,7 +63,7 @@ int psx_fm_editor_state_json(char *out, unsigned cap);
 /* Reset the cumulative low-overhead editor tick/event/present profiler. */
 void psx_fm_editor_profile_reset(void);
 /* Test/automation input through the same event path as a physical click or
- * Ctrl+1..5. keyboard=0 clicks the tab, nonzero sends the shortcut. */
+ * Ctrl+1..6. keyboard=0 clicks the tab, nonzero sends the shortcut. */
 int psx_fm_editor_inject_tab(int page, int keyboard);
 /* Native-window test/control seam. Negative x/y/w/h leave that component
  * unchanged. restore happens before resize/move; maximize and fit happen

--- a/src/texture_pack.c
+++ b/src/texture_pack.c
@@ -1,0 +1,2034 @@
+/* texture_pack.c -- see texture_pack.h.
+ *
+ * THE THREE THINGS THIS KEEPS TRACK OF
+ * -------------------------------------
+ *   assets   what the title told us its art is called, keyed by content hash.
+ *            Pure data, set up once, never invalidated.
+ *   regions  where art currently LIVES in VRAM. Built from uploads, torn down
+ *            whenever anything overwrites the rectangle. This is the part that
+ *            has to be correct or replacements attach to the wrong pixels.
+ *   entries  replacement images from the active pack, placed in the atlas.
+ *            Loaded lazily, on the first draw that actually wants one, so a
+ *            720-card pack does not cost 720 decodes at boot.
+ *
+ * WHY REGIONS EXPIRE
+ * -------------------
+ * VRAM is one megabyte that the game reuses constantly: the same address holds
+ * a card portrait now and a menu panel a moment later. A region therefore
+ * means "as of the last write, these words are that asset", and ANY later
+ * write over them ends it. Uploads, fills and VRAM->VRAM copies all invalidate,
+ * which is why the facade forwards all three rather than just transfers. Miss
+ * one and a pack eventually paints the wrong art onto something -- the failure
+ * is rare, timing-dependent and horrible to chase, so the invalidation is
+ * deliberately blunt: any overlap at all kills the region.
+ *
+ * THE RESOLVE CACHE
+ * ------------------
+ * texpack_on_draw() runs per primitive, and a scene is thousands of them, so
+ * the answer is cached against the primitive's texture state. A generation
+ * counter bumps on every invalidation, which retires the whole cache at a
+ * stroke -- correct by construction and cheaper than tracking which entries a
+ * particular rectangle touched.
+ *
+ * NOTHING HERE PRINTS. psxrecomp/CLAUDE.md rule 3 forbids printf/fprintf in
+ * runtime source outright: inspection goes through the TCP debug server, not
+ * stdout. So the things worth knowing -- how many assets the title registered,
+ * how many regions are live, and every reason a replacement was refused -- are
+ * COUNTED here and served by texpack_state_json(), the same shape the rest of
+ * this title uses (see psx_card_colors_state_json). A silently skipped
+ * replacement is the most likely thing to go wrong with a pack, so the refusal
+ * counters are the ones that matter: they turn "my art does not show up" into
+ * a number that says which of the three reasons it was.
+ */
+
+#include "texture_pack.h"
+
+#include <stdio.h>              /* snprintf only -- see the note below */
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>               /* scan_dir()'s wall-clock budget */
+
+#include "mod_plugins.h"        /* psx_mod_player_data_dir */
+/* The stb implementation lives in psx_window_icon.cpp and is built with
+ * STBI_NO_STDIO, so the filename-based stbi_load() does not exist -- only
+ * stbi_load_from_memory(). These defines must match that TU or the
+ * declarations here would promise functions nothing ever compiled. Reading the
+ * file first is the better shape anyway: it keeps the size cap and the I/O
+ * failure in one place instead of inside the decoder. */
+#define STBI_NO_STDIO
+#define STBI_ONLY_PNG
+#include "../psxrecomp/runtime/third_party/stb_image.h"
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  include <direct.h>
+#  define TP_MKDIR(p) _mkdir(p)
+#else
+#  include <dirent.h>
+#  include <sys/stat.h>
+#  define TP_MKDIR(p) mkdir((p), 0755)
+#endif
+
+#define TP_MAX_ASSETS   4096
+#define TP_MAX_REGIONS   256
+#define TP_MAX_ENTRIES  2048
+#define TP_MAX_PACKS      16
+#define TP_MAX_FILES    8192
+#define TP_NAME_MAX       96
+#define TP_PATH_MAX      512
+#define TP_CACHE         512
+#define TP_ATLAS_DIM    4096
+
+/* ---- assets: what the title named ---------------------------------------- */
+typedef struct {
+    uint64_t      hash;
+    char          name[TP_NAME_MAX];
+    int           w, h;           /* size the game samples (TILED, hashed) */
+    int           disp_w, disp_h; /* size on disk; == w,h unless retile != 0 */
+    int           page_w, page_h; /* whole image after retile */
+    int           src_x, src_y;   /* this page's origin within that image */
+    TexPackRetile retile;         /* display -> tiled, or 0 for raw assets */
+    /* Art the game uploads ONCE, before this framework is watching, can never
+     * be caught by hashing transfers -- the only transfer that carried it has
+     * already happened. Such an asset instead names the VRAM rectangle it is
+     * known to occupy, and is confirmed there by hashing that rectangle and
+     * comparing against the disc bytes. Position finds it; content still
+     * proves it, so a wrong guess about the position fails loudly rather than
+     * binding a region to whatever happens to sit there.
+     * anch_w == 0 means "not anchored: match by upload only". */
+    int           anch_x, anch_y; /* VRAM words */
+    int           anch_w, anch_h; /* VRAM words / rows */
+    /* Where the game last read this art's palette from. Some art's CLUT is
+     * not stored next to its pixels and has resisted being found on disc, so
+     * the exporter would have to write it as a grey index map -- which then
+     * REPLACES the properly coloured stock art, leaving the game looking
+     * worse than untouched. The renderer knows the answer: every draw carries
+     * its CLUT coordinates. Recording them lets the exporter read the real
+     * colours out of VRAM instead of guessing at them. */
+    /* A SNAPSHOT of the palette, taken when the art was drawn -- not the
+     * coordinates it lived at. Coordinates were the original bug: CLUT VRAM is
+     * reused constantly, so by the time an export asked, those words held some
+     * other screen's palette. ui/panels came back as pure red and green ramps
+     * that way, and every colour downstream of it was wrong. */
+    int           clut_snap;      /* slot in s_clutsnap, or -1 */
+    int           clut_n;         /* entries captured */
+    int           clut_seen;
+    int           tint;           /* see texpack_set_tinted() */
+    int           track_cluts;    /* record per-region palettes for this one */
+    int           no_plain;       /* see texpack_set_no_plain_fallback() */
+} TpAsset;
+
+static TpAsset  s_asset[TP_MAX_ASSETS];
+static int      s_asset_n;
+
+/* Palette snapshots. Only art with no palette in the title's own table ever
+ * needs one, which is a handful of UI sheets, so a small pool costs far less
+ * than 256 words on every asset. */
+#define TP_CLUTSNAP 32
+static uint16_t s_clutsnap[TP_CLUTSNAP][256];
+static int      s_clutsnap_n;
+
+/* WHICH PALETTE, WHERE.
+ *
+ * One palette per asset is not enough to describe a sheet the game draws
+ * through several: the dialogue frame's carved border is stone and its panel
+ * fill is navy, from the same pixels. But every draw tells us both the CLUT
+ * and the uv rectangle it covers, so the palettes can be recorded PER REGION
+ * and an export composed from them -- each part coloured the way the game
+ * actually colours it.
+ *
+ * Rectangles are in whole-image texel space so the exporter can use them
+ * directly. Deduped on rect+palette, since the same draw repeats every frame. */
+/* Generous on purpose. The dialogue frame alone is 11 rectangles, and a sheet
+ * is only fully described once every screen that draws it has been visited --
+ * so this fills up over a session rather than at once, and running out again
+ * silently truncates the very thing it is meant to record.
+ *
+ * 512 was not generous enough: a real session visiting dialog_frame, panels,
+ * duel_labels, the font, both logo screens, free_duel/background AND the
+ * menu labels all share this one pool, and texpack_state.py --cluts caught
+ * it completely full (512/512) with menu_labels_1/2 still only partly
+ * captured -- every region recorded after the pool filled was silently
+ * dropped, for every asset, not just the one being watched. Raised 8x; each
+ * entry is ~550 bytes (mostly the 256-entry uint16 pal[]), so 4096 is ~2.2MB,
+ * trivial on a desktop target. */
+#define TP_CLUTRECT 4096
+static struct {
+    int      asset;
+    int      x0, y0, x1, y1;      /* inclusive, image texels */
+    int      d0, e0, d1, e1;      /* where it last landed on screen */
+    int      has_dst;
+    int      n;                   /* palette entries */
+    uint16_t pal[256];
+} s_clutrect[TP_CLUTRECT];
+static int s_clutrect_n;
+
+static void note_clut_rect(int asset, int x0, int y0, int x1, int y1,
+                           const uint16_t *pal, int n, const int *dst)
+{
+    if (x1 < x0 || y1 < y0 || n <= 0)
+        return;
+
+    /* Swallow rectangles that another already covers, when the palette is the
+     * same. The game's uv bounds wobble by a texel between draws -- the same
+     * element arrives as 127x31 and again as 128x32 -- and it also draws a
+     * piece of a region it draws whole elsewhere. Each of those became its own
+     * exported file, so the pack filled with near-duplicates of one element.
+     * A contained rectangle under the same palette describes nothing new; a
+     * containing one replaces what it covers. Different palettes are always
+     * kept apart, since that is a different colouring, not a duplicate. */
+    for (int i = 0; i < s_clutrect_n; i++) {
+        if (s_clutrect[i].asset != asset || s_clutrect[i].n != n ||
+            memcmp(s_clutrect[i].pal, pal, (size_t)n * 2u) != 0)
+            continue;
+        if (x0 >= s_clutrect[i].x0 && y0 >= s_clutrect[i].y0 &&
+            x1 <= s_clutrect[i].x1 && y1 <= s_clutrect[i].y1)
+            return;                     /* already covered */
+        if (x0 <= s_clutrect[i].x0 && y0 <= s_clutrect[i].y0 &&
+            x1 >= s_clutrect[i].x1 && y1 >= s_clutrect[i].y1) {
+            s_clutrect[i].x0 = x0; s_clutrect[i].y0 = y0;
+            s_clutrect[i].x1 = x1; s_clutrect[i].y1 = y1;
+            return;                     /* grew to cover the old one */
+        }
+    }
+
+    /* Same rectangle, same palette: already known. Same rectangle under a
+     * DIFFERENT palette is not a duplicate and is never merged -- it is a
+     * different appearance of the same pixels, and choosing between them was
+     * the mistake this design replaces. Every heuristic tried (newest, most
+     * varied, widest contrast) picked wrongly for some screen, because the
+     * game means both: the Konami wordmark in black is as real as the white
+     * wash over it. Both are kept; both export; the CLUT of each draw picks
+     * the right one at run time. */
+    for (int i = 0; i < s_clutrect_n; i++) {
+        if (s_clutrect[i].asset == asset && s_clutrect[i].x0 == x0 &&
+            s_clutrect[i].y0 == y0 && s_clutrect[i].x1 == x1 &&
+            s_clutrect[i].y1 == y1 && s_clutrect[i].n == n &&
+            memcmp(s_clutrect[i].pal, pal, (size_t)n * 2u) == 0)
+            return;
+    }
+
+    if (s_clutrect_n >= TP_CLUTRECT)
+        return;
+    s_clutrect[s_clutrect_n].asset = asset;
+    s_clutrect[s_clutrect_n].x0 = x0; s_clutrect[s_clutrect_n].y0 = y0;
+    s_clutrect[s_clutrect_n].x1 = x1; s_clutrect[s_clutrect_n].y1 = y1;
+    s_clutrect[s_clutrect_n].n = n;
+    memcpy(s_clutrect[s_clutrect_n].pal, pal, (size_t)n * 2u);
+    s_clutrect[s_clutrect_n].has_dst = dst ? 1 : 0;
+    if (dst) {
+        s_clutrect[s_clutrect_n].d0 = dst[0]; s_clutrect[s_clutrect_n].e0 = dst[1];
+        s_clutrect[s_clutrect_n].d1 = dst[2]; s_clutrect[s_clutrect_n].e1 = dst[3];
+    }
+    s_clutrect_n++;
+}
+
+int texpack_clut_json(char *out, unsigned cap)
+{
+    unsigned n = (unsigned)snprintf(out, cap, "\"rects\":%d,\"list\":[",
+                                    s_clutrect_n);
+    if (n >= cap) return 0;
+    /* "p1" alone (index 1) was a fingerprint, not a diagnostic -- it cannot
+     * distinguish a real 16-colour gradient from 16 garbage words that happen
+     * to agree at one index. "pal" is the FULL captured palette, entry 0
+     * (usually transparent) through entry n-1, hex-encoded in one string so
+     * a person or tool can look at the whole thing at once. */
+    /* Worst case: 256 entries * 4 hex chars, 8bpp, plus the terminator. Was
+     * 513 -- half what 256 entries actually need -- which silently cut the
+     * dump off around entry 128 with no sign anything was missing; that was
+     * the only reason the wrong-depth capture bug below was still readable
+     * as a plausible-looking gradient instead of obviously running past a
+     * 16-entry 4bpp palette into more data than a 4bpp asset could have. */
+    char palhex[1025];
+    for (int i = 0; i < s_clutrect_n; i++) {
+        const int ai = s_clutrect[i].asset;
+        const int pn = (s_clutrect[i].n > 256) ? 256 : s_clutrect[i].n;
+        int ph = 0;
+        for (int e = 0; e < pn && ph + 4 < (int)sizeof palhex; e++)
+            ph += snprintf(palhex + ph, sizeof palhex - ph, "%04x", s_clutrect[i].pal[e]);
+        unsigned k = (unsigned)snprintf(out + n, cap - n,
+            "%s{\"name\":\"%s\",\"x0\":%d,\"y0\":%d,\"x1\":%d,\"y1\":%d,"
+            "\"p1\":\"%04x\",\"pal\":\"%s\"}",
+            i ? "," : "",
+            (ai >= 0 && ai < s_asset_n) ? s_asset[ai].name : "?",
+            s_clutrect[i].x0, s_clutrect[i].y0,
+            s_clutrect[i].x1, s_clutrect[i].y1, s_clutrect[i].pal[1], palhex);
+        if (k >= cap - n) break;      /* truncate the list, not the response */
+        n += k;
+    }
+    return (unsigned)snprintf(out + n, cap - n, "]") < cap - n;
+}
+
+int texpack_clut_rect_count(const char *name)
+{
+    if (!name) return 0;
+    int k = 0;
+    for (int i = 0; i < s_clutrect_n; i++) {
+        const int ai = s_clutrect[i].asset;
+        if (ai >= 0 && ai < s_asset_n && strcmp(s_asset[ai].name, name) == 0)
+            k++;
+    }
+    return k;
+}
+
+int texpack_clut_rect_dst(const char *name, int which,
+                          int *x0, int *y0, int *x1, int *y1)
+{
+    if (!name || which < 0)
+        return 0;
+    for (int i = 0; i < s_clutrect_n; i++) {
+        const int ai = s_clutrect[i].asset;
+        if (ai < 0 || ai >= s_asset_n || strcmp(s_asset[ai].name, name) != 0)
+            continue;
+        if (which-- > 0)
+            continue;
+        if (!s_clutrect[i].has_dst)
+            return 0;
+        *x0 = s_clutrect[i].d0; *y0 = s_clutrect[i].e0;
+        *x1 = s_clutrect[i].d1; *y1 = s_clutrect[i].e1;
+        return 1;
+    }
+    return 0;
+}
+
+int texpack_clut_rect_get(const char *name, int which,
+                          int *x0, int *y0, int *x1, int *y1,
+                          uint16_t *pal, int entries)
+{
+    if (!name || which < 0)
+        return 0;
+    for (int i = 0; i < s_clutrect_n; i++) {
+        const int ai = s_clutrect[i].asset;
+        if (ai < 0 || ai >= s_asset_n || strcmp(s_asset[ai].name, name) != 0)
+            continue;
+        if (which-- > 0)
+            continue;
+        if (s_clutrect[i].n < entries)
+            return 0;
+        *x0 = s_clutrect[i].x0; *y0 = s_clutrect[i].y0;
+        *x1 = s_clutrect[i].x1; *y1 = s_clutrect[i].y1;
+        if (pal && entries > 0)
+            memcpy(pal, s_clutrect[i].pal, (size_t)entries * 2u);
+        return 1;
+    }
+    return 0;
+}
+
+/* ---- regions: where art currently lives in VRAM --------------------------- */
+typedef struct {
+    int      x, y, w, h;        /* VRAM words */
+    int      asset;             /* index into s_asset, or -1 */
+} TpRegion;
+
+static TpRegion s_region[TP_MAX_REGIONS];
+static int      s_region_n;
+static unsigned s_generation = 1;
+
+/* Bumped ONLY when the active pack's file list is (re)scanned (activation or
+ * a manual reload) -- see reload_pack_files(). s_generation above is not a
+ * substitute: it also bumps on every single VRAM upload and draw-cache
+ * invalidation (many times a frame), so a caller that wants "the pack just
+ * became ready, re-check what it has" needs its own, far coarser counter.
+ * texpack_file_scan_generation() exposes it. */
+static unsigned s_file_scan_gen;
+
+/* ---- pack files and loaded entries ---------------------------------------- */
+typedef struct {
+    char name[TP_NAME_MAX];     /* pack-relative, no extension */
+    char path[TP_PATH_MAX];
+} TpFile;
+
+typedef struct {
+    int      file;              /* index into s_file */
+    int      src_x, src_y;      /* which page of that file this entry is */
+    int      w, h;              /* replacement pixels */
+    int      scale;
+    int      atlas_x, atlas_y;
+    uint8_t *rgba;              /* owned */
+    int      pending;           /* backend has not uploaded it yet */
+} TpEntry;
+
+static TpFile   s_file[TP_MAX_FILES];
+static int      s_file_n;
+static TpEntry  s_entry[TP_MAX_ENTRIES];
+static int      s_entry_n;
+
+static char     s_pack_name[TP_MAX_PACKS][TP_NAME_MAX];
+static char     s_pack_path[TP_MAX_PACKS][TP_PATH_MAX];
+static int      s_pack_n;
+static int      s_pack_active = -1;
+static int      s_enabled = 1;
+
+static const uint16_t *s_vram;
+
+/* atlas shelf allocator */
+static int s_shelf_x, s_shelf_y, s_shelf_h;
+
+/* Why replacements were refused, for texpack_state_json(). */
+static unsigned s_stat_decode_fail;    /* PNG would not decode */
+static unsigned s_stat_scale_reject;   /* not a whole multiple of the source */
+static unsigned s_stat_atlas_full;     /* no room left in the atlas */
+static unsigned s_stat_missing;        /* indexed, then deleted from disk */
+/* Draw-path counters. Region counts above come from UPLOADS, so they say
+ * nothing about whether a draw ever resolved -- these do. */
+static unsigned s_stat_resolved;       /* draws that found a region */
+static unsigned s_stat_clut_skip;      /* ...whose CLUT could not be captured */
+/* Diagnostic only: the raw flag and vertex colour of the LAST successfully
+ * replaced primitive. gpu_gl_renderer.c has both already (they are the game's
+ * own GPU-command state, unrelated to replacement), and they answer a real
+ * question the decomp project's own notes raised -- this dialogue is drawn
+ * with SetPolyGT4 (Gouraud-shaded textured quads), which can tint a texture
+ * with a per-vertex colour the replacement path has never accounted for. If
+ * raw==0 and col is far from white, that tint is the missing piece: the
+ * shader already multiplies replacement output by it, so a non-white tint
+ * here explains a colour mismatch with no bug in the hash/palette machinery
+ * at all. */
+static int   s_dbg_last_raw = -1;
+static float s_dbg_last_col[3];
+void texpack_debug_note_prim(int rawtex, const float col[3])
+{
+    s_dbg_last_raw = rawtex ? 1 : 0;
+    s_dbg_last_col[0] = col[0]; s_dbg_last_col[1] = col[1]; s_dbg_last_col[2] = col[2];
+}
+static int      s_stat_clut_last[3];   /* last skipped: depth, clut_x, clut_y */
+static unsigned s_stat_uploads;        /* transfers seen */
+static unsigned s_stat_matched;        /* ...that named a registered asset */
+static unsigned s_stat_anchor_ok;      /* anchored assets confirmed in VRAM */
+static unsigned s_stat_anchor_miss;    /* ...anchored but not what was there */
+static uint64_t s_stat_anchor_hash;    /* what the last miss found instead */
+/* Distinct upload SHAPES seen (deduped by w x h), newest kept, with a hit
+ * count. This is the honest way to answer "what shape does a background
+ * arrive in, and does it ever match" without one giant full-VRAM blit hiding
+ * everything smaller. */
+#define TP_SHAPES 24
+static struct { int w, h; unsigned seen, matched; } s_shape[TP_SHAPES];
+static int s_shape_n;
+
+/* Strip coalescer. The game uploads a background not as one 128x512 page but
+ * as 32 vertically-stacked 128x16 strips, one transfer each -- so the
+ * whole-page hash never matches an upload. This tracks a run of same-x,
+ * same-width, vertically-contiguous uploads and keeps a ROLLING hash of the
+ * bytes seen so far. Because FNV-1a is incremental, that rolling hash equals a
+ * registered asset's hash exactly when the strips have assembled precisely
+ * that asset -- at which point the whole page is matched and a region emitted,
+ * as if it had arrived in one transfer. */
+static int      s_bld_x = -1, s_bld_w, s_bld_y0, s_bld_yend;
+static uint64_t s_bld_hash;
+/* Diagnostics: the tallest strip-run ever assembled, and of runs that reached
+ * at least 512 rows (background height) how many matched a registration. Tells
+ * "strips never assemble a full page" (interleaved) from "they assemble but I
+ * registered the wrong bytes". */
+static int      s_bld_max_h;
+static unsigned s_bld_tall_runs, s_bld_tall_matched;
+static uint64_t s_bld_tall_hash;   /* hash of the last unmatched >=512 run */
+static int      s_bld_tall_x, s_bld_tall_y;
+
+/* Log of finished strip runs -- a run ends when it matches, or when the next
+ * upload does not continue it. Recording geometry AND rolling hash is what
+ * lets an asset that the game splits across VRAM be identified offline: the
+ * hash of each piece can be searched for on the disc. */
+#define TP_RUNLOG 10
+static struct { int x, y, w, h, matched; uint64_t hash; } s_runlog[TP_RUNLOG];
+static int s_runlog_n, s_runlog_head;
+
+/* Textured draws that found no containing region, deduped by texture state.
+ * A region can be live and still never be drawn FROM -- if the glyphs sample
+ * a page we did not register, this is where that shows up, as a texpage with
+ * a high count and no match.
+ *
+ * A REAL RING, not a first-N-wins cap. 12 slots used to fill permanently
+ * with whatever ran first in a session and then silently refuse every new
+ * distinct pattern for the rest of it -- diagnosing "what's unresolved on
+ * THIS screen, right now" was impossible once a long session had already
+ * saturated the table with patterns from screens visited earlier. Evicting
+ * the OLDEST slot when full (same head-rotation shape as s_runlog below)
+ * means the most recently discovered distinct patterns are always visible,
+ * which is what a live "why isn't this asset drawing" check actually needs.
+ * Raised the size too: 12 was tight even for a short session once several
+ * assets are being investigated in the same run. */
+#define TP_UNRES 64
+static struct { int bx, by, depth, x0, y0, x1, y1; unsigned n; } s_unres[TP_UNRES];
+static int s_unres_n, s_unres_head;
+
+static void note_unresolved(int bx, int by, int depth,
+                            int x0, int y0, int x1, int y1)
+{
+    for (int i = 0; i < s_unres_n; i++)
+        if (s_unres[i].bx == bx && s_unres[i].by == by &&
+            s_unres[i].depth == depth) { s_unres[i].n++; return; }
+    const int slot = s_unres_head;
+    s_unres[slot].bx = bx; s_unres[slot].by = by;
+    s_unres[slot].depth = depth;
+    s_unres[slot].x0 = x0; s_unres[slot].y0 = y0;
+    s_unres[slot].x1 = x1; s_unres[slot].y1 = y1;
+    s_unres[slot].n = 1;
+    s_unres_head = (s_unres_head + 1) % TP_UNRES;
+    if (s_unres_n < TP_UNRES) s_unres_n++;
+}
+
+/* VRAM-to-VRAM copies whose SOURCE overlaps a registered region -- see
+ * texpack_note_copy()'s header comment in texture_pack.h for why this exists
+ * at all. Deduped on (asset, destination): the same background redrawing the
+ * same compositing step every frame is one fact, not one entry per frame. */
+#define TP_COPYLOG 12
+static struct { int asset; int sx, sy, sw, sh; int dx, dy; unsigned n; } s_copylog[TP_COPYLOG];
+static int s_copylog_n;
+
+void texpack_note_copy(int sx, int sy, int w, int h, int dx, int dy)
+{
+    if (w <= 0 || h <= 0 || !s_region_n)
+        return;
+    const int sx1 = sx + w - 1, sy1 = sy + h - 1;
+    for (int i = 0; i < s_region_n; i++) {
+        const TpRegion *r = &s_region[i];
+        if (sx > r->x + r->w - 1 || sx1 < r->x ||
+            sy > r->y + r->h - 1 || sy1 < r->y)
+            continue;               /* source does not touch this region */
+        int found = 0;
+        for (int k = 0; k < s_copylog_n; k++)
+            if (s_copylog[k].asset == r->asset &&
+                s_copylog[k].dx == dx && s_copylog[k].dy == dy) {
+                s_copylog[k].n++;
+                found = 1;
+                break;
+            }
+        if (!found && s_copylog_n < TP_COPYLOG) {
+            s_copylog[s_copylog_n].asset = r->asset;
+            s_copylog[s_copylog_n].sx = sx; s_copylog[s_copylog_n].sy = sy;
+            s_copylog[s_copylog_n].sw = w;  s_copylog[s_copylog_n].sh = h;
+            s_copylog[s_copylog_n].dx = dx; s_copylog[s_copylog_n].dy = dy;
+            s_copylog[s_copylog_n].n = 1;
+            s_copylog_n++;
+        }
+    }
+}
+
+static void runlog_add(int x, int y, int w, int h, int matched, uint64_t hash)
+{
+    if (h <= 0) return;
+    int i = s_runlog_head;
+    s_runlog[i].x = x; s_runlog[i].y = y; s_runlog[i].w = w; s_runlog[i].h = h;
+    s_runlog[i].matched = matched; s_runlog[i].hash = hash;
+    s_runlog_head = (s_runlog_head + 1) % TP_RUNLOG;
+    if (s_runlog_n < TP_RUNLOG) s_runlog_n++;
+}
+
+static void bld_reset(void) { s_bld_x = -1; }
+
+static void note_shape(int w, int h, int matched)
+{
+    for (int i = 0; i < s_shape_n; i++)
+        if (s_shape[i].w == w && s_shape[i].h == h) {
+            s_shape[i].seen++;
+            if (matched) s_shape[i].matched++;
+            return;
+        }
+    if (s_shape_n < TP_SHAPES) {
+        s_shape[s_shape_n].w = w; s_shape[s_shape_n].h = h;
+        s_shape[s_shape_n].seen = 1; s_shape[s_shape_n].matched = matched ? 1 : 0;
+        s_shape_n++;
+    }
+}
+
+/* A page of one repeated value carries no identity: 32 KB of zeroes occurs
+ * 1117 times in this title's art file alone, so ANY blank VRAM page would
+ * "match" whichever blank asset happened to register first and get painted
+ * with its replacement. Uniform content is therefore never matched and never
+ * registered -- there is nothing there to replace. */
+static int uniform16(const uint16_t *p, unsigned n)
+{
+    for (unsigned i = 1; i < n; i++)
+        if (p[i] != p[0])
+            return 0;
+    return 1;
+}
+
+/* ---- hashing -------------------------------------------------------------- */
+#define FNV_OFFSET 1469598103934665603ULL
+static uint64_t fnv_update(uint64_t h, const void *data, unsigned len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    for (unsigned i = 0; i < len; i++) { h ^= p[i]; h *= 1099511628211ULL; }
+    return h;
+}
+
+uint64_t texpack_hash(const void *data, unsigned len)
+{
+    /* FNV-1a. The title hashes disc bytes with this same function, so both
+     * sides must see the same byte order -- which they do, since a PS1 upload
+     * payload is little-endian halfwords and so is the disc it came from.
+     * Incremental (fnv_update) so a run of strip uploads can be hashed as one
+     * page -- see the strip coalescer in texpack_on_upload. */
+    return fnv_update(FNV_OFFSET, data, len);
+}
+
+int texpack_register_asset_page(const char *name, uint64_t hash,
+                                int w, int h, int disp_w, int disp_h,
+                                int page_w, int page_h,
+                                int src_x, int src_y, TexPackRetile retile)
+{
+    if (!name || !*name || w <= 0 || h <= 0 || disp_w <= 0 || disp_h <= 0)
+        return 0;
+    if (s_asset_n >= TP_MAX_ASSETS)
+        return 0;
+    for (int i = 0; i < s_asset_n; i++)
+        if (s_asset[i].hash == hash)
+            return 1;
+    TpAsset *a = &s_asset[s_asset_n++];
+    a->hash = hash; a->w = w; a->h = h;
+    a->disp_w = disp_w; a->disp_h = disp_h;
+    a->page_w = page_w; a->page_h = page_h;
+    a->src_x = src_x; a->src_y = src_y;
+    a->retile = retile;
+    a->anch_x = a->anch_y = a->anch_w = a->anch_h = 0;
+    a->clut_snap = -1;
+    a->clut_n = a->clut_seen = 0;
+    a->tint = 0;
+    a->track_cluts = 0;
+    a->no_plain = 0;
+    snprintf(a->name, sizeof a->name, "%s", name);
+    return 1;
+}
+
+int texpack_register_asset_tiled(const char *name, uint64_t hash,
+                                 int w, int h, int disp_w, int disp_h,
+                                 TexPackRetile retile)
+{
+    if (!name || !*name || w <= 0 || h <= 0 || disp_w <= 0 || disp_h <= 0)
+        return 0;
+    if (s_asset_n >= TP_MAX_ASSETS)
+        return 0;
+    for (int i = 0; i < s_asset_n; i++)
+        if (s_asset[i].hash == hash)
+            return 1;           /* first name for a hash wins */
+    TpAsset *a = &s_asset[s_asset_n++];
+    a->hash = hash;
+    a->w = w;
+    a->h = h;
+    a->disp_w = disp_w;
+    a->disp_h = disp_h;
+    a->page_w = w;
+    a->page_h = h;
+    a->src_x = 0;
+    a->src_y = 0;
+    a->retile = retile;
+    a->anch_x = a->anch_y = a->anch_w = a->anch_h = 0;
+    a->clut_snap = -1;
+    a->clut_n = a->clut_seen = 0;
+    a->tint = 0;
+    a->track_cluts = 0;
+    a->no_plain = 0;
+    snprintf(a->name, sizeof a->name, "%s", name);
+    return 1;
+}
+
+int texpack_register_asset(const char *name, uint64_t hash, int w, int h)
+{
+    return texpack_register_asset_tiled(name, hash, w, h, w, h, 0);
+}
+
+int texpack_register_asset_anchored(const char *name, uint64_t hash,
+                                    int w, int h,
+                                    int vram_x, int vram_y,
+                                    int vram_w, int vram_h)
+{
+    if (vram_w <= 0 || vram_h <= 0)
+        return 0;
+    const int before = s_asset_n;
+    if (!texpack_register_asset(name, hash, w, h))
+        return 0;
+    if (s_asset_n == before)
+        return 1;               /* this hash was already named; leave it be */
+    TpAsset *a = &s_asset[s_asset_n - 1];
+    a->anch_x = vram_x; a->anch_y = vram_y;
+    a->anch_w = vram_w; a->anch_h = vram_h;
+    return 1;
+}
+
+static int asset_by_hash(uint64_t hash)
+{
+    for (int i = 0; i < s_asset_n; i++)
+        if (s_asset[i].hash == hash)
+            return i;
+    return -1;
+}
+
+/* ---- pack discovery ------------------------------------------------------- */
+static void add_file(const char *rel, const char *full)
+{
+    if (s_file_n >= TP_MAX_FILES)
+        return;
+    TpFile *f = &s_file[s_file_n++];
+    snprintf(f->name, sizeof f->name, "%s", rel);
+    snprintf(f->path, sizeof f->path, "%s", full);
+}
+
+/* Wall-clock budget for one whole scan_dir() tree walk, reset by whoever
+ * starts one (reload_pack_files()). A player's pack folder can be huge, or
+ * sit on a slow or cloud-synced drive where every single stat()/readdir()
+ * call carries real latency -- a starvation-watchdog abort seconds after
+ * launch, from exactly this walk running unbounded during boot, is what
+ * this guards against (found 2026-09-13). Once the deadline passes every
+ * level bails out without recursing further, so a slow or huge tree yields
+ * whatever it found in the time it had rather than blocking indefinitely;
+ * the pack is still usable for everything the partial scan did reach. */
+#define TP_SCAN_BUDGET_SECONDS 3
+static int   s_scan_over_budget;
+static time_t s_scan_deadline;
+
+/* Walk a pack directory, recording every .png under it by its path relative to
+ * the pack root and minus the extension -- which is exactly the name the title
+ * registered, so lookup is a string compare and nothing has to agree on a
+ * naming convention twice. */
+static void scan_dir(const char *root, const char *sub)
+{
+    if (s_scan_over_budget)
+        return;
+    if (time(NULL) >= s_scan_deadline) { s_scan_over_budget = 1; return; }
+
+    char dir[TP_PATH_MAX];
+    if (sub && *sub)
+        snprintf(dir, sizeof dir, "%s/%s", root, sub);
+    else
+        snprintf(dir, sizeof dir, "%s", root);
+
+#ifdef _WIN32
+    char glob[TP_PATH_MAX];
+    snprintf(glob, sizeof glob, "%s/*", dir);
+    WIN32_FIND_DATAA fd;
+    HANDLE h = FindFirstFileA(glob, &fd);
+    if (h == INVALID_HANDLE_VALUE)
+        return;
+    do {
+        if (s_scan_over_budget) break;
+        if (time(NULL) >= s_scan_deadline) { s_scan_over_budget = 1; break; }
+        const char *nm = fd.cFileName;
+        if (!strcmp(nm, ".") || !strcmp(nm, ".."))
+            continue;
+        char rel[TP_NAME_MAX];
+        if (sub && *sub) snprintf(rel, sizeof rel, "%s/%s", sub, nm);
+        else             snprintf(rel, sizeof rel, "%s", nm);
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            scan_dir(root, rel);
+        } else {
+            size_t n = strlen(rel);
+            if (n > 4 && !strcmp(rel + n - 4, ".png")) {
+                char full[TP_PATH_MAX];
+                snprintf(full, sizeof full, "%s/%s", root, rel);
+                rel[n - 4] = '\0';
+                add_file(rel, full);
+            }
+        }
+    } while (FindNextFileA(h, &fd));
+    FindClose(h);
+#else
+    DIR *dp = opendir(dir);
+    if (!dp)
+        return;
+    struct dirent *de;
+    while ((de = readdir(dp)) != NULL) {
+        if (s_scan_over_budget) break;
+        if (time(NULL) >= s_scan_deadline) { s_scan_over_budget = 1; break; }
+        const char *nm = de->d_name;
+        if (!strcmp(nm, ".") || !strcmp(nm, ".."))
+            continue;
+        char rel[TP_NAME_MAX];
+        if (sub && *sub) snprintf(rel, sizeof rel, "%s/%s", sub, nm);
+        else             snprintf(rel, sizeof rel, "%s", nm);
+        char full[TP_PATH_MAX];
+        snprintf(full, sizeof full, "%s/%s", root, rel);
+        struct stat st;
+        if (stat(full, &st) != 0)
+            continue;
+        if (S_ISDIR(st.st_mode)) {
+            scan_dir(root, rel);
+        } else {
+            size_t n = strlen(rel);
+            if (n > 4 && !strcmp(rel + n - 4, ".png")) {
+                rel[n - 4] = '\0';
+                add_file(rel, full);
+            }
+        }
+    }
+    closedir(dp);
+#endif
+}
+
+/* One pack, always: <player-data>/textures, registered so psx_wa_catalog.c's
+ * build_catalog() auto-activates it at boot ("one pack directory means that
+ * pack is the one you meant") -- the same folder texpack_active_dir()'s
+ * fallback already names on its own, so this just makes it live instead of
+ * only ever agreed-upon by construction.
+ *
+ * This used to be unconditional here too, until 2026-09-13: a player whose
+ * player-data lives under a slow or cloud-synced folder hit a starvation-
+ * watchdog abort seconds after launch, from scan_dir() -- the recursive walk
+ * that activating a pack triggers -- blocking during boot with no bound on
+ * how long it could take. Pulling activation out entirely (require opening
+ * the Textures page first) traded that crash for HD replacement silently
+ * never turning on for a player who never happened to open that page, which
+ * is worse for everyone who was never at risk in the first place. The actual
+ * fix is scan_dir()'s own wall-clock budget (TP_SCAN_BUDGET_SECONDS, above)
+ * -- bounded, so this registration is safe to be unconditional again. */
+static void discover_packs(void)
+{
+    const char *base = psx_mod_player_data_dir();
+    if (!base || !*base)
+        return;
+    char root[TP_PATH_MAX];
+    snprintf(root, sizeof root, "%s/textures", base);
+    TP_MKDIR(root);
+    snprintf(s_pack_name[0], TP_NAME_MAX, "textures");
+    snprintf(s_pack_path[0], TP_PATH_MAX, "%s", root);
+    s_pack_n = 1;
+}
+
+void texpack_init(void)
+{
+    static int done;
+    if (done)
+        return;
+    done = 1;
+    discover_packs();
+}
+
+void texpack_shutdown(void)
+{
+    for (int i = 0; i < s_entry_n; i++) {
+        free(s_entry[i].rgba);
+        s_entry[i].rgba = NULL;
+    }
+    s_entry_n = 0;
+    s_file_n = 0;
+    s_region_n = 0;
+}
+
+static void rescan_anchored(int vw, int vh, const uint16_t *data);
+
+void texpack_set_vram(const uint16_t *vram) { s_vram = vram; }
+
+/* Anchored art is resident: it is in VRAM continuously, not delivered by an
+ * event we can hook. So it is looked for against the live mirror rather than
+ * only when a whole-VRAM write happens to arrive -- a session that never
+ * restores a savestate would otherwise never resolve it at all. Assets
+ * already placed are skipped, so the steady-state cost is a scan of a handful
+ * of registrations. */
+/* Ask for this art's palettes to be recorded per drawn region.
+ *
+ * Off by default, because the pool is shared and small: with every card
+ * claiming a slot it filled long before the UI was ever drawn, and the assets
+ * that actually need this -- the ones whose palette the title cannot supply --
+ * silently got none. Cards do not need it; their palette sits beside their
+ * pixels. */
+/* Refuse to fall back to the plain whole-sheet file for this asset.
+ *
+ * That file can only ever hold ONE colouring of a sheet the game draws with
+ * several -- an old file left over from a since-deleted composite pipeline,
+ * or a single hand-painted sheet, would otherwise silently apply itself to a
+ * draw under a different palette and look wrong with no indication why.
+ * Without a matching per-draw element such a draw stays stock, which is
+ * always correctly coloured, rather than a guess. */
+int texpack_set_no_plain_fallback(const char *name, int on)
+{
+    if (!name)
+        return 0;
+    int hit = 0;
+    for (int i = 0; i < s_asset_n; i++)
+        if (strcmp(s_asset[i].name, name) == 0) {
+            s_asset[i].no_plain = on ? 1 : 0;
+            hit = 1;
+        }
+    return hit;
+}
+
+int texpack_set_track_cluts(const char *name, int on)
+{
+    if (!name)
+        return 0;
+    int hit = 0;
+    for (int i = 0; i < s_asset_n; i++)
+        if (strcmp(s_asset[i].name, name) == 0) {
+            s_asset[i].track_cluts = on ? 1 : 0;
+            hit = 1;
+        }
+    return hit;
+}
+
+int texpack_set_anchor(const char *name, int src_y,
+                       int vram_x, int vram_y, int vram_w, int vram_h)
+{
+    if (!name || vram_w <= 0 || vram_h <= 0)
+        return 0;
+    for (int i = 0; i < s_asset_n; i++) {
+        if (s_asset[i].src_y != src_y || strcmp(s_asset[i].name, name) != 0)
+            continue;
+        s_asset[i].anch_x = vram_x; s_asset[i].anch_y = vram_y;
+        s_asset[i].anch_w = vram_w; s_asset[i].anch_h = vram_h;
+        return 1;
+    }
+    return 0;
+}
+
+int texpack_set_tinted(const char *name, int on)
+{
+    if (!name)
+        return 0;
+    int hit = 0;
+    for (int i = 0; i < s_asset_n; i++)
+        if (strcmp(s_asset[i].name, name) == 0) {
+            s_asset[i].tint = on ? 1 : 0;
+            hit = 1;
+        }
+    return hit;
+}
+
+int texpack_observed_clut(const char *name, uint16_t *out, int entries)
+{
+    return texpack_observed_clut_page(name, 0, out, entries);
+}
+
+/* Art taller than a texture page is registered as several bands sharing one
+ * name, and those bands need not share a palette -- the UI sheet is glyphs on
+ * top and stone panelling below, drawn through entirely different CLUTs. So
+ * the band has to be part of the key, or every band reports whichever one
+ * happened to be drawn first and the rest export in the wrong colours. */
+int texpack_observed_clut_page(const char *name, int src_y,
+                               uint16_t *out, int entries)
+{
+    if (!name || !out || entries <= 0 || !s_vram)
+        return 0;
+    for (int i = 0; i < s_asset_n; i++) {
+        const TpAsset *a = &s_asset[i];
+        if (!a->clut_seen || a->src_y != src_y || strcmp(a->name, name) != 0)
+            continue;
+        if (a->clut_snap < 0 || a->clut_n < entries)
+            return 0;
+        memcpy(out, s_clutsnap[a->clut_snap],
+               (size_t)entries * sizeof(uint16_t));
+        return 1;
+    }
+    return 0;
+}
+
+void texpack_resolve_anchors(void)
+{
+    if (s_vram && s_asset_n)
+        rescan_anchored(1024, 512, s_vram);
+}
+
+int         texpack_pack_count(void)        { return s_pack_n; }
+const char *texpack_pack_name(int i)
+{
+    return (i >= 0 && i < s_pack_n) ? s_pack_name[i] : NULL;
+}
+const char *texpack_pack_path(int i)
+{
+    return (i >= 0 && i < s_pack_n) ? s_pack_path[i] : NULL;
+}
+int         texpack_active_pack(void)       { return s_pack_active; }
+int         texpack_enabled(void)           { return s_enabled; }
+
+/* discover_packs() registers <player-data>/textures as pack 0 once
+ * texpack_init() has run, so the active branch below is the normal case --
+ * this fallback mainly covers a call that lands before that (or before
+ * player-data is known at all, where "." is at least something). */
+void texpack_active_dir(char *out, unsigned cap)
+{
+    if (!out || !cap) return;
+    const char *path = (s_pack_active >= 0) ? s_pack_path[s_pack_active] : NULL;
+    if (path && *path) { snprintf(out, cap, "%s", path); return; }
+    const char *base = psx_mod_player_data_dir();
+    snprintf(out, cap, "%s/textures", base && *base ? base : ".");
+}
+
+void texpack_set_enabled(int on)
+{
+    on = on ? 1 : 0;
+    if (on == s_enabled)
+        return;
+    s_enabled = on;
+    /* The resolve cache holds decisions made under the old setting, so it has
+     * to be retired -- otherwise cached hits would keep drawing replacements
+     * after the toggle went off. Bumping the generation retires all of it at
+     * once, the same way an invalidation does. */
+    s_generation++;
+}
+int         texpack_atlas_dim(void)         { return TP_ATLAS_DIM; }
+
+
+/* Throw away everything derived from the pack's FILES and read the directory
+ * again. Registrations and regions survive -- those describe the game's own
+ * art and have not changed -- so only the decoded pictures and the atlas are
+ * rebuilt, lazily, as things are next drawn.
+ *
+ * This is what makes an edited PNG appear without restarting: entries cache
+ * decoded pixels for the life of the process, so without dropping them a file
+ * changed on disk is never read a second time. */
+static void reload_pack_files(void)
+{
+    for (int i = 0; i < s_entry_n; i++) {
+        free(s_entry[i].rgba);
+        s_entry[i].rgba = NULL;
+    }
+    s_entry_n = 0;
+    s_file_n = 0;
+    s_shelf_x = s_shelf_y = s_shelf_h = 0;
+    s_generation++;
+    if (s_pack_active >= 0) {
+        s_scan_over_budget = 0;
+        s_scan_deadline = time(NULL) + TP_SCAN_BUDGET_SECONDS;
+        scan_dir(s_pack_path[s_pack_active], NULL);
+        s_stat_decode_fail = s_stat_scale_reject = s_stat_atlas_full = 0;
+        s_stat_missing = 0;
+    }
+    s_file_scan_gen++;
+}
+
+/* Reloading walks the pack directory and frees decoded art, so it must not run
+ * from a menu callback while the renderer is resolving a draw. The request is
+ * a flag; texpack_reload_if_pending() does the work from the frame hook, the
+ * same split every other toggle in this title uses. */
+static int s_reload_req;
+
+void texpack_request_reload(void) { s_reload_req = 1; }
+
+void texpack_reload_if_pending(void)
+{
+    if (!s_reload_req)
+        return;
+    s_reload_req = 0;
+    reload_pack_files();
+}
+
+void texpack_set_active_pack(int index)
+{
+    if (index == s_pack_active)
+        return;
+    s_pack_active = (index >= 0 && index < s_pack_n) ? index : -1;
+    reload_pack_files();
+}
+
+void texpack_set_active_dir(const char *path)
+{
+    if (!path || !*path)
+        return;
+    for (int i = 0; i < s_pack_n; i++)
+        if (!strcmp(s_pack_path[i], path)) { texpack_set_active_pack(i); return; }
+    const int slot = (s_pack_n < TP_MAX_PACKS) ? s_pack_n++ : TP_MAX_PACKS - 1;
+    const char *base = strrchr(path, '/');
+#ifdef _WIN32
+    const char *base_bs = strrchr(path, '\\');
+    if (base_bs && (!base || base_bs > base)) base = base_bs;
+#endif
+    snprintf(s_pack_name[slot], TP_NAME_MAX, "%s", base ? base + 1 : path);
+    snprintf(s_pack_path[slot], TP_PATH_MAX, "%s", path);
+    /* Force texpack_set_active_pack's reload below even when `slot` happens
+     * to already equal s_pack_active (the array-full reuse case): the path
+     * just written into it changed, but the index did not. */
+    s_pack_active = -1;
+    texpack_set_active_pack(slot);
+}
+
+/* ---- regions -------------------------------------------------------------- */
+static int rects_overlap(const TpRegion *r, int x, int y, int w, int h)
+{
+    return !(x >= r->x + r->w || x + w <= r->x ||
+             y >= r->y + r->h || y + h <= r->y);
+}
+
+static void drop_overlapping(int x, int y, int w, int h)
+{
+    for (int i = 0; i < s_region_n; ) {
+        if (rects_overlap(&s_region[i], x, y, w, h))
+            s_region[i] = s_region[--s_region_n];
+        else
+            i++;
+    }
+}
+
+void texpack_invalidate_rect(int x, int y, int w, int h)
+{
+    if (w <= 0 || h <= 0)
+        return;
+    int before = s_region_n;
+    drop_overlapping(x, y, w, h);
+    if (s_region_n != before)
+        s_generation++;
+}
+
+void texpack_invalidate_all(void)
+{
+    s_region_n = 0;
+    s_generation++;
+    bld_reset();
+}
+
+static void coalesce_strip(int x, int y, int w, int h, const uint16_t *data);
+
+/* A whole-VRAM write (savestate restore, boot handoff) replaces everything at
+ * once. Discarding our regions there is correct but leaves art that the game
+ * uploaded ONCE and never re-uploads -- the UI font sheet above all --
+ * permanently unmatchable: the only transfer that ever carried it has already
+ * happened. The blit itself contains that art, though, so rather than throw it
+ * away we re-derive regions from it: hash every 64x256 texture-page slot and
+ * re-register the ones we recognise. 32 slots, 1 MB of hashing, once. */
+#define TP_PAGE_W 64
+#define TP_PAGE_H 256
+/* Scratch for one anchored rectangle: a full texture page is the largest one
+ * that can sensibly be claimed, so it is also the ceiling. */
+#define TP_ANCH_MAX (TP_PAGE_W * TP_PAGE_H)
+
+/* Confirm each anchored asset at the rectangle it claims. Hashing the
+ * rectangle and comparing against the registration is what keeps this honest:
+ * the position says where to look, the content still decides. A miss records
+ * what WAS there, because the usual cause is a rectangle of the wrong height
+ * and that hash identifies the right one. */
+/* Index of asset's live region, or -1. */
+static int anchor_region_index(int asset)
+{
+    for (int i = 0; i < s_region_n; i++)
+        if (s_region[i].asset == asset)
+            return i;
+    return -1;
+}
+
+static void rescan_anchored(int vw, int vh, const uint16_t *data)
+{
+    static uint16_t rect[TP_ANCH_MAX];
+    if (!data)
+        return;
+    for (int i = 0; i < s_asset_n; i++) {
+        const TpAsset *a = &s_asset[i];
+        if (!a->anch_w)
+            continue;
+        const size_t n = (size_t)a->anch_w * (size_t)a->anch_h;
+        if (n > TP_ANCH_MAX ||
+            a->anch_x + a->anch_w > vw || a->anch_y + a->anch_h > vh)
+            continue;
+
+        /* Re-hashed EVERY scan, even once already live.
+         *
+         * An anchor claims a FIXED VRAM rectangle, but nothing keeps that
+         * rectangle exclusive to this asset -- the game is free to reuse the
+         * same texture page for a totally different screen's art, and
+         * nothing routes that change through texpack_on_upload() if it
+         * happens by a GPU fill/blit rather than a tracked CPU->VRAM
+         * transfer. The old code took "already live" as permanent proof of
+         * occupancy and never looked again, so once some OTHER menu's
+         * graphics moved into an anchored rectangle, every draw that
+         * legitimately sampled it kept being served this asset's stale
+         * content forever -- a hazard-stripe dialog border came out in
+         * duel_labels' navy-and-white because duel_labels' anchor had
+         * silently kept "owning" VRAM that the game had long since
+         * repurposed. Checking every time costs a few small hashes per
+         * frame, which is cheap next to getting this wrong permanently. */
+        for (int r = 0; r < a->anch_h; r++)
+            memcpy(rect + (size_t)r * a->anch_w,
+                   data + (size_t)(a->anch_y + r) * vw + a->anch_x,
+                   (size_t)a->anch_w * sizeof(uint16_t));
+        const uint64_t got = texpack_hash(rect, (unsigned)(n * 2));
+        const int live = anchor_region_index(i);
+
+        if (got != a->hash) {
+            s_stat_anchor_miss++;
+            s_stat_anchor_hash = got;
+            if (live >= 0) {
+                /* No longer this asset's content: release the claim so
+                 * whatever is actually there now can be matched normally
+                 * (by upload hash) or simply draws stock, either of which
+                 * is correct -- unlike continuing to hand out this asset's
+                 * art for someone else's VRAM. */
+                s_region[live] = s_region[--s_region_n];
+            }
+            continue;
+        }
+        if (live >= 0)
+            continue;           /* already claimed and still correct */
+
+        if (s_region_n >= TP_MAX_REGIONS)
+            s_region_n = TP_MAX_REGIONS - 1;
+        TpRegion *rg = &s_region[s_region_n++];
+        rg->x = a->anch_x; rg->y = a->anch_y;
+        rg->w = a->anch_w; rg->h = a->anch_h;
+        rg->asset = i;
+        s_stat_anchor_ok++;
+        s_stat_matched++;
+    }
+}
+
+static void rescan_vram(int w, int h, const uint16_t *data)
+{
+    static uint16_t page[TP_PAGE_W * TP_PAGE_H];
+    for (int py = 0; py + TP_PAGE_H <= h; py += TP_PAGE_H) {
+        for (int px = 0; px + TP_PAGE_W <= w; px += TP_PAGE_W) {
+            for (int r = 0; r < TP_PAGE_H; r++)
+                memcpy(page + (size_t)r * TP_PAGE_W,
+                       data + (size_t)(py + r) * w + px,
+                       TP_PAGE_W * sizeof(uint16_t));
+            if (uniform16(page, TP_PAGE_W * TP_PAGE_H))
+                continue;       /* blank page: see uniform16 */
+            const int asset = asset_by_hash(
+                texpack_hash(page, sizeof page));
+            if (asset < 0)
+                continue;
+            if (s_region_n >= TP_MAX_REGIONS)
+                s_region_n = TP_MAX_REGIONS - 1;
+            TpRegion *rg = &s_region[s_region_n++];
+            rg->x = px; rg->y = py;
+            rg->w = TP_PAGE_W; rg->h = TP_PAGE_H;
+            rg->asset = asset;
+            s_stat_matched++;
+        }
+    }
+    rescan_anchored(w, h, data);
+}
+
+void texpack_on_upload(int x, int y, int w, int h, const uint16_t *data)
+{
+    if (w <= 0 || h <= 0 || !data)
+        return;
+
+    /* Whatever was here is gone regardless of whether we can name the new
+     * contents, so the invalidation happens before the lookup, not after it. */
+    drop_overlapping(x, y, w, h);
+    s_generation++;
+    s_stat_uploads++;
+
+    if (!s_asset_n)
+        return;                 /* title registered nothing; nothing to name */
+
+    /* A blit big enough to be the whole framebuffer is not one asset -- it is
+     * everything at once. Recover what we can recognise inside it. */
+    if (w >= 512 && h >= 512) {
+        rescan_vram(w, h, data);
+        bld_reset();
+        return;
+    }
+
+    /* A uniform upload identifies nothing, but it must still be FED to the
+     * coalescer: a background arrives as 16-row strips and some of those rows
+     * are legitimately blank, so returning early here broke the rolling hash
+     * mid-page and the whole background stopped assembling. Only the match is
+     * suppressed, never the accumulation. (Blank pages cannot match anyway --
+     * psx_wa_catalog.c refuses to register uniform bands.) */
+    const uint64_t hash = texpack_hash(data, (unsigned)(w * h) * 2u);
+    const int asset = uniform16(data, (unsigned)(w * h))
+                    ? -1 : asset_by_hash(hash);
+    note_shape(w, h, asset >= 0);
+    if (asset < 0) {
+        coalesce_strip(x, y, w, h, data);   /* maybe a piece of a strip run */
+        return;
+    }
+    bld_reset();                /* a whole-upload match breaks any strip run */
+
+    if (s_region_n >= TP_MAX_REGIONS)
+        s_region_n = TP_MAX_REGIONS - 1;   /* newest wins over the oldest */
+    TpRegion *r = &s_region[s_region_n++];
+    r->x = x; r->y = y; r->w = w; r->h = h;
+    r->asset = asset;
+    s_stat_matched++;
+}
+
+/* Fold one upload into the vertical-strip run and, if the run has now
+ * assembled a registered asset, emit a region for the whole page. Called for
+ * every upload; a run that does not continue simply restarts here. */
+static void coalesce_strip(int x, int y, int w, int h, const uint16_t *data)
+{
+    if (x == s_bld_x && w == s_bld_w && y == s_bld_yend) {
+        /* continues the current run */
+    } else {
+        if (s_bld_x >= 0)      /* the run that just ended, unmatched */
+            runlog_add(s_bld_x, s_bld_y0, s_bld_w,
+                       s_bld_yend - s_bld_y0, 0, s_bld_hash);
+        s_bld_x = x; s_bld_w = w; s_bld_y0 = y;
+        s_bld_yend = y; s_bld_hash = FNV_OFFSET;
+    }
+    s_bld_hash = fnv_update(s_bld_hash, data, (unsigned)(w * h) * 2u);
+    s_bld_yend = y + h;
+    if (s_bld_yend - s_bld_y0 > s_bld_max_h) s_bld_max_h = s_bld_yend - s_bld_y0;
+
+    const int asset = asset_by_hash(s_bld_hash);
+    if (s_bld_yend - s_bld_y0 >= 512) {
+        s_bld_tall_runs++;
+        if (asset >= 0) s_bld_tall_matched++;
+        else { s_bld_tall_hash = s_bld_hash;
+               s_bld_tall_x = s_bld_x; s_bld_tall_y = s_bld_y0; }
+    }
+    if (asset < 0)
+        return;
+
+    const int ph = s_bld_yend - s_bld_y0;
+    if (s_region_n >= TP_MAX_REGIONS)
+        s_region_n = TP_MAX_REGIONS - 1;
+    TpRegion *r = &s_region[s_region_n++];
+    r->x = s_bld_x; r->y = s_bld_y0; r->w = s_bld_w; r->h = ph;
+    r->asset = asset;
+    s_stat_matched++;
+    runlog_add(s_bld_x, s_bld_y0, s_bld_w, ph, 1, s_bld_hash);
+    bld_reset();                /* page complete; next strip starts fresh */
+}
+
+/* ---- entries: loading a replacement --------------------------------------- */
+static int find_file(const char *name)
+{
+    for (int i = 0; i < s_file_n; i++)
+        if (!strcmp(s_file[i].name, name))
+            return i;
+    return -1;
+}
+
+int texpack_has_replacement(const char *name)
+{
+    if (!s_enabled || s_pack_active < 0 || !name || !*name)
+        return 0;
+    return find_file(name) >= 0;
+}
+
+unsigned texpack_file_scan_generation(void) { return s_file_scan_gen; }
+
+static int atlas_place(int w, int h, int *ox, int *oy)
+{
+    if (w > TP_ATLAS_DIM || h > TP_ATLAS_DIM)
+        return 0;
+    if (s_shelf_x + w > TP_ATLAS_DIM) {         /* next shelf */
+        s_shelf_y += s_shelf_h;
+        s_shelf_x = 0;
+        s_shelf_h = 0;
+    }
+    if (s_shelf_y + h > TP_ATLAS_DIM)
+        return 0;                               /* atlas full */
+    *ox = s_shelf_x;
+    *oy = s_shelf_y;
+    s_shelf_x += w;
+    if (h > s_shelf_h)
+        s_shelf_h = h;
+    return 1;
+}
+
+/* Whole-file read, then decode. TP_FILE_MAX caps it so a stray large file in
+ * a pack directory cannot be turned into an allocation by naming alone. */
+#define TP_FILE_MAX (64u * 1024u * 1024u)
+
+static stbi_uc *load_png(const char *path, int *w, int *h, int *comp)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        /* Indexed at scan time, gone now. Counted apart from a decode failure
+         * because the two mean opposite things: one is a broken PNG, the other
+         * is a pack that has changed under us and wants reloading. */
+        s_stat_missing++;
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return NULL; }
+    long len = ftell(f);
+    if (len <= 0 || (unsigned long)len > TP_FILE_MAX) { fclose(f); return NULL; }
+    rewind(f);
+    unsigned char *buf = (unsigned char *)malloc((size_t)len);
+    if (!buf) { fclose(f); return NULL; }
+    size_t got = fread(buf, 1, (size_t)len, f);
+    fclose(f);
+    if (got != (size_t)len) { free(buf); return NULL; }
+    stbi_uc *px = stbi_load_from_memory(buf, (int)len, w, h, comp, 4);
+    free(buf);
+    return px;
+}
+
+/* Load a file as the replacement for asset `a`. Returns an entry index, or -1.
+ *
+ * The file on disk is DISPLAY layout (a->disp_w x a->disp_h). For a raw asset
+ * that equals the sampled size and the loaded pixels are used as-is. For a
+ * tiled asset (a->retile != 0) the loaded picture is a clean scene and has to
+ * be repacked into the a->w x a->h layout the game samples, at the same
+ * integer scale, before it enters the atlas. */
+static int entry_load(int file, const TpAsset *a)
+{
+    /* Keyed on the PAGE, not the file: several pages of a tall image share one
+     * file, and matching on file alone would hand every page the first page's
+     * pixels. */
+    for (int i = 0; i < s_entry_n; i++)
+        if (s_entry[i].file == file &&
+            s_entry[i].src_x == a->src_x && s_entry[i].src_y == a->src_y)
+            return i;
+    if (s_entry_n >= TP_MAX_ENTRIES)
+        return -1;
+
+    int w = 0, h = 0, comp = 0;
+    stbi_uc *px = load_png(s_file[file].path, &w, &h, &comp);
+    if (!px) {
+        s_stat_decode_fail++;
+        return -1;
+    }
+    /* Validate against the DISPLAY size -- that is what the file is. */
+    if (w % a->disp_w || h % a->disp_h ||
+        w / a->disp_w != h / a->disp_h || w < a->disp_w) {
+        s_stat_scale_reject++;      /* see the header on why fractional fails */
+        stbi_image_free(px);
+        return -1;
+    }
+    const int scale = w / a->disp_w;
+
+    /* 1. retile the WHOLE image, if this family is stored scrambled. */
+    stbi_uc *page = px;
+    int pw = w, ph = h;
+    if (a->retile) {
+        pw = a->page_w * scale;
+        ph = a->page_h * scale;
+        page = (stbi_uc *)malloc((size_t)pw * (size_t)ph * 4u);
+        if (!page) { stbi_image_free(px); return -1; }
+        a->retile(px, w, h, page, pw, ph);
+        stbi_image_free(px);
+    }
+
+    /* 2. crop out just this page. A PS1 texture page is at most 256 rows, so a
+     *    taller image arrives as several uploads and each is its own asset
+     *    cropped from the same picture. */
+    const int aw = a->w * scale, ah = a->h * scale;
+    const int sx = a->src_x * scale, sy = a->src_y * scale;
+    stbi_uc *atlas_px;
+    if (sx == 0 && sy == 0 && aw == pw && ah == ph) {
+        atlas_px = page;                 /* whole image is the page */
+    } else {
+        if (sx + aw > pw || sy + ah > ph) {
+            if (a->retile) free(page); else stbi_image_free(page);
+            s_stat_scale_reject++;
+            return -1;
+        }
+        atlas_px = (stbi_uc *)malloc((size_t)aw * (size_t)ah * 4u);
+        if (!atlas_px) {
+            if (a->retile) free(page); else stbi_image_free(page);
+            return -1;
+        }
+        for (int y = 0; y < ah; y++)
+            memcpy(atlas_px + (size_t)y * aw * 4u,
+                   page + ((size_t)(sy + y) * pw + sx) * 4u,
+                   (size_t)aw * 4u);
+        if (a->retile) free(page); else stbi_image_free(page);
+    }
+
+    int ax, ay;
+    if (!atlas_place(aw, ah, &ax, &ay)) {
+        s_stat_atlas_full++;
+        free(atlas_px);
+        return -1;
+    }
+
+    TpEntry *e = &s_entry[s_entry_n];
+    e->file = file;
+    e->src_x = a->src_x;
+    e->src_y = a->src_y;
+    e->w = aw;
+    e->h = ah;
+    e->scale = scale;
+    e->atlas_x = ax;
+    e->atlas_y = ay;
+    e->rgba = atlas_px;
+    e->pending = 1;
+    return s_entry_n++;
+}
+
+int texpack_take_pending(int *x, int *y, int *w, int *h, const uint8_t **rgba)
+{
+    for (int i = 0; i < s_entry_n; i++) {
+        if (!s_entry[i].pending)
+            continue;
+        s_entry[i].pending = 0;
+        *x = s_entry[i].atlas_x;
+        *y = s_entry[i].atlas_y;
+        *w = s_entry[i].w;
+        *h = s_entry[i].h;
+        *rgba = s_entry[i].rgba;
+        return 1;
+    }
+    return 0;
+}
+
+/* ---- draw-time resolve ---------------------------------------------------- */
+/* The resolve cache. The key MUST include the sampled uv bounds, not just the
+ * texture state: one 64-word texpage spans two 256-row VRAM pages, so a quad
+ * drawing the left half and a quad drawing the right half share base_x,
+ * base_y, depth and CLUT entirely -- they differ only in which texels they
+ * read. Keyed without `lim`, the second quad inherited the first quad's
+ * answer, sampled past the end of that page's atlas entry, and discarded as
+ * transparent: a background whose left third replaced correctly while the rest
+ * went black. */
+typedef struct {
+    unsigned   gen;
+    int        base_x, base_y, depth, clut_x, clut_y;
+    int        lim[4];
+    int        hit;
+    TexPackHit out;
+} TpCache;
+
+static TpCache s_cache[TP_CACHE];
+
+/* VRAM is addressed with WRAPAROUND, which is what the GPU does -- the shader
+ * has always used `ivec2(x & 1023, y & 511)`. Returning zero past the edge
+ * instead made this disagree with the renderer for any CLUT near the right of
+ * VRAM: a 256-entry palette at x=896 needs 1152 columns, so it wraps to the
+ * start of its own line. Reading zeros there produced a wrong CLUT hash and,
+ * worse, made the capture guard below reject those palettes entirely. */
+static uint16_t vram_at(int x, int y)
+{
+    if (!s_vram)
+        return 0;
+    return s_vram[(y & 511) * 1024 + (x & 1023)];
+}
+
+/* The CLUT a primitive draws through, hashed, so a pack can hold one image per
+ * palette variant. 4bpp reads 16 entries, 8bpp 256, and a 16bpp primitive has
+ * no CLUT at all. */
+/* A palette's identity, as 128 bits.
+ *
+ * 64 bits is not enough: this is a hash of only 32-512 bytes of highly
+ * structured data (BGR555 palette entries), sampled across a whole session's
+ * worth of distinct UI colourings, and two GENUINELY DIFFERENT palettes were
+ * found to collide under plain FNV-1a-64 -- a dialogue border's real yellow
+ * palette and an unrelated blue one exported earlier landed on the identical
+ * 64-bit digest, so the injector confidently served the wrong file. Two
+ * independent 64-bit FNV-1a runs (second one salted so it is not simply the
+ * same computation twice) make that practically impossible without needing a
+ * cryptographic hash. */
+void texpack_hash128(const void *data, unsigned len, uint64_t out[2])
+{
+    out[0] = fnv_update(FNV_OFFSET, data, len);
+    uint64_t h = fnv_update(FNV_OFFSET ^ 0x9E3779B97F4A7C15ULL, data, len);
+    out[1] = fnv_update(h, "\x5A", 1);
+}
+
+static void clut_hash(int depth, int clut_x, int clut_y, uint64_t out[2])
+{
+    int n = (depth == 0) ? 16 : (depth == 1) ? 256 : 0;
+    if (!n) { out[0] = out[1] = 0; return; }
+    uint16_t buf[256];
+    for (int i = 0; i < n; i++)
+        buf[i] = vram_at(clut_x + i, clut_y);
+    texpack_hash128(buf, (unsigned)n * 2u, out);
+}
+
+/* ---- unknown-asset capture -------------------------------------------------
+ * See texture_pack.h. Everything here runs only when texpack_on_draw has
+ * already decided "no region claims this primitive" -- it never competes
+ * with, slows down, or changes the result of the replacement path above.
+ *
+ * Kept as a flat, ever-growing, NEVER-consumed pile rather than a drained
+ * queue: a game layer groups pieces that sit next to each other on screen
+ * (one panel's worth of icons, one logo's worth of bands) the same way
+ * write_screens() groups a known asset's recorded regions, and the piece
+ * that completes a group may not turn up until several frames after the
+ * first one in it -- so nothing here can be thrown away just because it was
+ * looked at once already. */
+#define TP_CAP_ALL     128  /* distinct captures kept for the session */
+#define TP_CAP_MAX_DIM 256  /* a texture page is never wider or taller */
+
+static int      s_capture_enabled;
+
+typedef struct {
+    int base_x, base_y, depth, clut_x, clut_y;
+    int lim[4];
+    int dst[4];
+    int w, h;
+    uint8_t *rgba;
+    int anch_x, anch_y, anch_w, anch_h;
+    uint16_t *raw;
+    uint64_t key;    /* dedup identity: see maybe_capture */
+} TpCapSlot;
+static TpCapSlot s_capture_all[TP_CAP_ALL];
+static int       s_capture_all_n;
+
+void texpack_set_capture_enabled(int on) { s_capture_enabled = on ? 1 : 0; }
+int  texpack_capture_enabled(void)       { return s_capture_enabled; }
+
+static int capture_already_seen(uint64_t key)
+{
+    /* Linear, but TP_CAP_ALL is small and this only runs on the already-rare
+     * "no region matched" path, not per frame. */
+    for (int i = 0; i < s_capture_all_n; i++)
+        if (s_capture_all[i].key == key)
+            return 1;
+    return 0;
+}
+
+/* Decode the rectangle this primitive samples through its own live CLUT --
+ * the same unpacking texpack_on_draw already knows (tpw texels per VRAM
+ * word), just writing pixels out instead of only reading the palette. 0x0000
+ * is the PS1's own transparency convention, followed everywhere else in this
+ * project's disc-side decoding (psx_wa_catalog.c), so it is followed here
+ * too: a capture reads exactly like a disc-decoded asset would. */
+static void maybe_capture(int base_x, int base_y, int depth,
+                         int clut_x, int clut_y, const int lim[4],
+                         const int dst[4])
+{
+    if (!s_capture_enabled || !s_vram || !lim)
+        return;
+
+    const uint64_t key = (uint64_t)(unsigned)base_x * 1000003u
+                       ^ (uint64_t)(unsigned)base_y * 999983u << 12
+                       ^ (uint64_t)(unsigned)depth  * 65599u  << 24
+                       ^ (uint64_t)(unsigned)clut_x * 31u     << 32
+                       ^ (uint64_t)(unsigned)clut_y * 131u    << 40
+                       ^ (uint64_t)(unsigned)(lim[0] * 5 + lim[1] * 11
+                                             + lim[2] * 7 + lim[3] * 13);
+    if (capture_already_seen(key))
+        return;
+
+    const int tpw = (depth == 0) ? 4 : (depth == 1) ? 2 : 1;
+    const int w = lim[2] - lim[0] + 1, h = lim[3] - lim[1] + 1;
+    if (w <= 0 || h <= 0 || w > TP_CAP_MAX_DIM || h > TP_CAP_MAX_DIM)
+        return;
+
+    const int cn = (depth == 0) ? 16 : (depth == 1) ? 256 : 0;
+    uint16_t pal[256];
+    if (cn && clut_x >= 0 && clut_y >= 0)
+        for (int e = 0; e < cn; e++)
+            pal[e] = vram_at(clut_x + e, clut_y);
+
+    uint8_t *rgba = (uint8_t *)malloc((size_t)w * (size_t)h * 4u);
+    if (!rgba)
+        return;
+
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            const int tx = lim[0] + x, ty = lim[1] + y;
+            uint16_t v;
+            if (depth == 2) {
+                v = vram_at(base_x + tx, base_y + ty);
+            } else {
+                const uint16_t word = vram_at(base_x + tx / tpw, base_y + ty);
+                const unsigned idx = (depth == 0) ? (word >> ((tx & 3) * 4)) & 0xFu
+                                                  : (word >> ((tx & 1) * 8)) & 0xFFu;
+                v = (cn && (int)idx < cn) ? pal[idx] : 0;
+            }
+            uint8_t *q = rgba + (size_t)(y * w + x) * 4u;
+            q[0] = (uint8_t)(((v      ) & 31) * 255 / 31);
+            q[1] = (uint8_t)(((v >>  5) & 31) * 255 / 31);
+            q[2] = (uint8_t)(((v >> 10) & 31) * 255 / 31);
+            q[3] = v ? 255 : 0;
+        }
+    }
+
+    /* The SAME rectangle, word-aligned, raw (not palette-decoded) -- exactly
+     * what rescan_anchored() reads and hashes for an anchor check. lim[] is
+     * texel-granular and need not fall on a word boundary, so the anchor's
+     * word span is the words CONTAINING lim[0]..lim[2], which for a 16bpp
+     * primitive (tpw 1) is the same range either way. */
+    const int word0 = lim[0] / tpw, word1 = lim[2] / tpw;
+    const int anch_x = base_x + word0, anch_y = base_y + lim[1];
+    const int anch_w = word1 - word0 + 1, anch_h = h;
+    uint16_t *raw = (uint16_t *)malloc((size_t)anch_w * (size_t)anch_h * sizeof(uint16_t));
+    if (!raw) { free(rgba); return; }
+    for (int r = 0; r < anch_h; r++)
+        for (int c = 0; c < anch_w; c++)
+            raw[(size_t)r * anch_w + c] = vram_at(anch_x + c, anch_y + r);
+
+    if (s_capture_all_n >= TP_CAP_ALL) {
+        /* Pool full: stop accepting new ones rather than evicting what a
+         * game layer may already be part-way through grouping -- the same
+         * "keep what is already recorded" choice s_clutrect's own pool-full
+         * case makes, and for the same reason (silently truncating on this
+         * side of the join would be worse than silently truncating here). */
+        free(rgba); free(raw);
+        return;
+    }
+    TpCapSlot *slot = &s_capture_all[s_capture_all_n++];
+    slot->base_x = base_x; slot->base_y = base_y; slot->depth = depth;
+    slot->clut_x = clut_x; slot->clut_y = clut_y;
+    slot->lim[0] = lim[0]; slot->lim[1] = lim[1];
+    slot->lim[2] = lim[2]; slot->lim[3] = lim[3];
+    if (dst) { slot->dst[0]=dst[0]; slot->dst[1]=dst[1]; slot->dst[2]=dst[2]; slot->dst[3]=dst[3]; }
+    else     { slot->dst[0]=slot->dst[1]=slot->dst[2]=slot->dst[3]=0; }
+    slot->w = w; slot->h = h; slot->rgba = rgba; slot->key = key;
+    slot->anch_x = anch_x; slot->anch_y = anch_y;
+    slot->anch_w = anch_w; slot->anch_h = anch_h; slot->raw = raw;
+}
+
+int texpack_capture_count(void) { return s_capture_all_n; }
+
+int texpack_capture_get(int i, TexPackCapture *out)
+{
+    if (!out || i < 0 || i >= s_capture_all_n)
+        return 0;
+    const TpCapSlot *s = &s_capture_all[i];
+    out->base_x = s->base_x; out->base_y = s->base_y; out->depth = s->depth;
+    out->clut_x = s->clut_x; out->clut_y = s->clut_y;
+    memcpy(out->lim, s->lim, sizeof out->lim);
+    memcpy(out->dst, s->dst, sizeof out->dst);
+    out->w = s->w; out->h = s->h; out->rgba = s->rgba;   /* borrowed */
+    out->anch_x = s->anch_x; out->anch_y = s->anch_y;
+    out->anch_w = s->anch_w; out->anch_h = s->anch_h;
+    out->raw = s->raw;                                    /* borrowed */
+    return 1;
+}
+
+int texpack_on_draw(int base_x, int base_y, int depth,
+                    int clut_x, int clut_y, const int lim[4],
+                    const int dst[4], TexPackHit *out)
+{
+    if (!s_enabled || s_pack_active < 0 || !s_region_n || !lim)
+        return 0;
+
+    unsigned slot = (unsigned)(base_x * 31 + base_y * 17 + depth * 7
+                               + clut_x * 3 + clut_y
+                               + lim[0] * 5 + lim[1] * 11) % TP_CACHE;
+    TpCache *c = &s_cache[slot];
+    if (c->gen == s_generation && c->base_x == base_x && c->base_y == base_y &&
+        c->depth == depth && c->clut_x == clut_x && c->clut_y == clut_y &&
+        c->lim[0] == lim[0] && c->lim[1] == lim[1] &&
+        c->lim[2] == lim[2] && c->lim[3] == lim[3]) {
+        if (c->hit)
+            *out = c->out;
+        return c->hit;
+    }
+
+    c->gen = s_generation;
+    c->base_x = base_x; c->base_y = base_y; c->depth = depth;
+    c->clut_x = clut_x; c->clut_y = clut_y;
+    c->lim[0] = lim[0]; c->lim[1] = lim[1];
+    c->lim[2] = lim[2]; c->lim[3] = lim[3];
+    c->hit = 0;
+
+    /* texels per VRAM word at this depth */
+    const int tpw = (depth == 0) ? 4 : (depth == 1) ? 2 : 1;
+
+    /* the VRAM words this primitive samples */
+    const int x0 = base_x + lim[0] / tpw;
+    const int x1 = base_x + lim[2] / tpw;
+    const int y0 = base_y + lim[1];
+    const int y1 = base_y + lim[3];
+
+    /* newest region that fully contains them */
+    int found = -1;
+    for (int i = s_region_n - 1; i >= 0; i--) {
+        const TpRegion *r = &s_region[i];
+        if (x0 >= r->x && x1 < r->x + r->w &&
+            y0 >= r->y && y1 < r->y + r->h) {
+            found = i;
+            break;
+        }
+    }
+    if (found < 0) {
+        note_unresolved(base_x, base_y, depth, x0, y0, x1, y1);
+        maybe_capture(base_x, base_y, depth, clut_x, clut_y, lim, dst);
+        return 0;
+    }
+
+    const TpRegion *r = &s_region[found];
+    TpAsset *a = &s_asset[r->asset];
+
+    /* The containment test above is purely geometric: it asks whether this
+     * primitive's WORD-space sample rectangle falls inside the region, not
+     * whether the primitive is actually drawing this asset's content. A
+     * region wide enough for one asset can geometrically contain a totally
+     * unrelated primitive sampling at a DIFFERENT bit depth -- same VRAM
+     * words, different meaning entirely, because tpw (texels per word)
+     * changes with depth. That mismatch is invisible to x0/x1/y0/y1, which
+     * are already computed through this primitive's own tpw.
+     *
+     * ui/menu_labels_1 (bpp 4, expects depth 0) is the confirmed case: a
+     * depth-1 primitive geometrically inside the same anchored region got
+     * captured as its "palette" -- 256 real VRAM words, smoothly graduated
+     * because they are real image content, just not this asset's palette at
+     * all. The result was legible-shaped but wrong-coloured "static" on
+     * every export, and no amount of checking the disc bytes or the decode
+     * math would ever have found it, because both were already correct. */
+    /* TpAsset carries no bpp field of its own, but an ANCHORED asset's own
+     * anch_w (VRAM words) against its w (texels) already says what depth it
+     * was registered at -- texels per word is exactly what tpw above is,
+     * just computed the other way round. Non-anchored (upload-hash-matched)
+     * assets are not checked here: their region identity already came from
+     * an actual content hash on the real upload, not a geometric guess, so
+     * the specific failure mode this guards against does not apply to them
+     * the same way. */
+    if (a->anch_w > 0) {
+        const int reg_tpw = a->w / a->anch_w;
+        const int expect_depth = (reg_tpw == 4) ? 0 : (reg_tpw == 2) ? 1 : (reg_tpw == 1) ? 2 : -1;
+        if (expect_depth >= 0 && depth != expect_depth) {
+            note_unresolved(base_x, base_y, depth, x0, y0, x1, y1);
+            maybe_capture(base_x, base_y, depth, clut_x, clut_y, lim, dst);
+            return 0;
+        }
+    }
+
+    /* Capture the palette CONTENTS while they are still the ones being used.
+     * Noted even when no replacement exists: the exporter needs this precisely
+     * for the art nobody has painted over yet. */
+    s_stat_resolved++;
+    const int cn = (depth == 0) ? 16 : (depth == 1) ? 256 : 0;
+    if (!(cn && s_vram && clut_x >= 0 && clut_y >= 0)) {
+        s_stat_clut_skip++;
+        s_stat_clut_last[0] = depth;
+        s_stat_clut_last[1] = clut_x;
+        s_stat_clut_last[2] = clut_y;
+    }
+    if (cn && s_vram && clut_x >= 0 && clut_y >= 0) {
+        if (a->clut_snap < 0 && s_clutsnap_n < TP_CLUTSNAP)
+            a->clut_snap = s_clutsnap_n++;
+        if (a->clut_snap >= 0) {
+            /* Entry by entry, wrapped -- a 256-entry CLUT starting near the
+             * right edge runs off it and continues at column 0 of the same
+             * line, so a flat copy would read past the row and a bounds check
+             * would refuse it. */
+            for (int e = 0; e < cn; e++)
+                s_clutsnap[a->clut_snap][e] = vram_at(clut_x + e, clut_y);
+            a->clut_n = cn;
+            a->clut_seen = 1;
+            /* ...and the same palette against the rectangle it applies to,
+             * in whole-image texels: what this primitive samples, shifted by
+             * where the region sits in the page and which band it is. */
+            const int ou = (r->x - base_x) * tpw, ov = r->y - base_y;
+            if (a->track_cluts)
+                note_clut_rect(r->asset,
+                               lim[0] - ou + a->src_x, lim[1] - ov + a->src_y,
+                               lim[2] - ou + a->src_x, lim[3] - ov + a->src_y,
+                               s_clutsnap[a->clut_snap], cn, dst);
+        }
+    }
+
+    uint64_t ch2[2];
+    clut_hash(depth, clut_x, clut_y, ch2);
+
+    /* PER-ELEMENT file first, if the pack has one.
+     *
+     * A UI page is a dense sheet of unrelated icons and labels with no blank
+     * rows between them, so any split of the page into files is arbitrary --
+     * and mine put icons in with labels. The game's own draw calls are not
+     * arbitrary: each one samples exactly one element. So a pack may supply a
+     * file per element, named for the rectangle the draw covers, and it wins
+     * over the whole-page file.
+     *
+     * The name has to be derived the same way the exporter derives it, from
+     * the same lim, or nothing matches. */
+    const int e_ou = (r->x - base_x) * tpw, e_ov = r->y - base_y;
+    const int ix0 = lim[0] - e_ou + a->src_x, iy0 = lim[1] - e_ov + a->src_y;
+    const int ix1 = lim[2] - e_ou + a->src_x, iy1 = lim[3] - e_ov + a->src_y;
+    if (ix1 >= ix0 && iy1 >= iy0) {
+        char sub[TP_NAME_MAX];
+        /* Palette-specific element first: the same rectangle is drawn through
+         * different CLUTs and each has its own file. Falls back to the plain
+         * name for packs that supply just one. */
+        int sfile = -1, spal = 0;
+        if ((ch2[0] || ch2[1]) &&
+            snprintf(sub, sizeof sub, "%s/%d_%d_%dx%d@%016llx%016llx", a->name,
+                     ix0, iy0, ix1 - ix0 + 1, iy1 - iy0 + 1,
+                     (unsigned long long)ch2[0], (unsigned long long)ch2[1])
+                < (int)sizeof sub) {
+            sfile = find_file(sub);
+            spal = (sfile >= 0);
+        }
+        if (snprintf(sub, sizeof sub, "%s/%d_%d_%dx%d", a->name, ix0, iy0,
+                     ix1 - ix0 + 1, iy1 - iy0 + 1) < (int)sizeof sub) {
+            if (sfile < 0) sfile = find_file(sub);
+            if (sfile >= 0) {
+                TpAsset sa = *a;            /* a standalone image, not a page */
+                sa.w = sa.disp_w = sa.page_w = ix1 - ix0 + 1;
+                sa.h = sa.disp_h = sa.page_h = iy1 - iy0 + 1;
+                sa.src_x = sa.src_y = 0;
+                sa.retile = 0;
+                const int se = entry_load(sfile, &sa);
+                if (se >= 0) {
+                    c->out.atlas_x = (float)s_entry[se].atlas_x;
+                    c->out.atlas_y = (float)s_entry[se].atlas_y;
+                    c->out.org_u   = (float)(ix0 + e_ou - a->src_x);
+                    c->out.org_v   = (float)(iy0 + e_ov - a->src_y);
+                    c->out.scale   = (float)s_entry[se].scale;
+                    /* Palette-specific art can only match under its own CLUT,
+                     * so drawing it flat is always colour-correct -- and flat
+                     * is what lets a tinted sheet's elements be true HD instead
+                     * of HD-alpha-only. The palette-agnostic fallback keeps
+                     * the asset's tint semantics. */
+                    /* a->tint is tri-state (-1/0/1): a plain truthiness check
+                     * here would treat -1 (explicitly opted OUT of tinting) as
+                     * tinted, since -1 is non-zero in C. Only tint==1 counts. */
+                    c->out.mode    = spal ? 0 : (a->tint > 0 ? 1 : 0);
+                    c->hit = 1;
+                    *out = c->out;
+                    return 1;
+                }
+            }
+        }
+    }
+
+    /* Most specific file wins:
+     *   <name>@<cluthash>  painted for exactly this palette
+     *   <name>.idx         an INDEX map -- works under every palette
+     *   <name>             ordinary art, drawn flat or tinted per the asset
+     *
+     * The .idx form is what lets a replacement behave like the game's own art
+     * on a sheet drawn through several CLUTs: it keeps the indirection the
+     * console has and a painted RGBA file throws away. */
+    int file = -1;
+    /* Tri-state: only tint==1 means tinted. A plain truthiness check would
+     * also fire for tint==-1 (explicitly opted out), since -1 is non-zero. */
+    int mode = a->tint > 0 ? 1 : 0;
+    if (ch2[0] || ch2[1]) {
+        char keyed[TP_NAME_MAX];
+        snprintf(keyed, sizeof keyed, "%s@%016llx%016llx", a->name,
+                 (unsigned long long)ch2[0], (unsigned long long)ch2[1]);
+        file = find_file(keyed);
+    }
+    if (file < 0) {
+        char ix[TP_NAME_MAX];
+        snprintf(ix, sizeof ix, "%s.idx", a->name);
+        file = find_file(ix);
+        if (file >= 0)
+            mode = 2;
+    }
+    /* The plain whole-sheet fallback is skipped for per-palette UI art
+     * (not tinted, but still UI). That file can only ever hold ONE colouring,
+     * which is the exact ambiguity this design exists to avoid -- an old file
+     * left over from the deleted composite/heuristic pipeline, or a single
+     * hand-painted sheet, would otherwise silently apply itself to draws under
+     * a DIFFERENT palette and look wrong with no indication why. Without a
+     * matching per-draw element, such a draw is stock, which is always
+     * correctly coloured, rather than a guess. */
+    if (file < 0 && !a->no_plain)
+        file = find_file(a->name);
+    if (file < 0)
+        return 0;
+
+    const int entry = entry_load(file, a);
+    if (entry < 0)
+        return 0;
+
+    const TpEntry *e = &s_entry[entry];
+    c->out.atlas_x = (float)e->atlas_x;
+    c->out.atlas_y = (float)e->atlas_y;
+    c->out.org_u   = (float)((r->x - base_x) * tpw);
+    c->out.org_v   = (float)(r->y - base_y);
+    c->out.scale   = (float)e->scale;
+    c->out.mode    = mode;
+    c->hit = 1;
+    *out = c->out;
+    return 1;
+}
+
+
+/* ---- diagnostics ---------------------------------------------------------- */
+
+/* Hash of every 64x256 texture-page slot currently in VRAM, with the asset it
+ * resolves to (empty when unknown). Reported on demand rather than only on a
+ * whole-VRAM blit, so what a screen ACTUALLY has resident can be compared
+ * against the disc -- which is how a page the game draws from but we never
+ * registered gets identified. */
+int texpack_vram_pages_json(char *out, unsigned cap)
+{
+    static uint16_t page[TP_PAGE_W * TP_PAGE_H];
+    unsigned n = (unsigned)snprintf(out, cap, "\"pages\":[");
+    if (n >= cap) return 0;
+    int first = 1;
+    for (int py = 0; py + TP_PAGE_H <= 512; py += TP_PAGE_H) {
+        for (int px = 0; px + TP_PAGE_W <= 1024; px += TP_PAGE_W) {
+            if (!s_vram) break;
+            for (int r = 0; r < TP_PAGE_H; r++)
+                memcpy(page + (size_t)r * TP_PAGE_W,
+                       s_vram + (size_t)(py + r) * 1024 + px,
+                       TP_PAGE_W * sizeof(uint16_t));
+            const uint64_t h = texpack_hash(page, sizeof page);
+            const int a = asset_by_hash(h);
+            unsigned k = (unsigned)snprintf(out + n, cap - n,
+                "%s{\"x\":%d,\"y\":%d,\"h\":\"%016llx\",\"a\":\"%s\"}",
+                first ? "" : ",", px, py, (unsigned long long)h,
+                a >= 0 ? s_asset[a].name : "");
+            if (k >= cap - n) return 0;
+            n += k; first = 0;
+        }
+    }
+    return (unsigned)snprintf(out + n, cap - n, "]") < cap - n;
+}
+int texpack_state_json(char *out, unsigned cap)
+{
+    const char *pack = (s_pack_active >= 0) ? s_pack_name[s_pack_active] : "";
+    unsigned n = (unsigned)snprintf(
+        out, cap,
+        "\"enabled\":%d,\"packs\":%d,\"active\":%d,\"pack\":\"%s\",\"files\":%d,"
+        "\"assets\":%d,\"regions\":%d,\"loaded\":%d,"
+        "\"uploads\":%u,\"matched\":%u,"
+        "\"anchor\":{\"ok\":%u,\"miss\":%u,\"hash\":\"%016llx\"},"
+        "\"draw\":{\"resolved\":%u,\"clut_skip\":%u,\"rects\":%d,"
+        "\"last_depth\":%d,\"last_cx\":%d,\"last_cy\":%d,"
+        "\"last_raw\":%d,\"last_col\":[%.3f,%.3f,%.3f]},"
+        "\"runs\":{\"max_h\":%d,\"tall\":%u,\"tall_matched\":%u,"
+        "\"hash\":\"%016llx\",\"x\":%d,\"y\":%d},"
+        "\"refused\":{\"decode\":%u,\"scale\":%u,\"atlas_full\":%u,"
+        "\"missing\":%u},\"unres\":[",
+        s_enabled, s_pack_n, s_pack_active, pack, s_file_n,
+        s_asset_n, s_region_n, s_entry_n,
+        s_stat_uploads, s_stat_matched,
+        s_stat_anchor_ok, s_stat_anchor_miss,
+        (unsigned long long)s_stat_anchor_hash,
+        s_stat_resolved, s_stat_clut_skip, s_clutrect_n,
+        s_stat_clut_last[0], s_stat_clut_last[1], s_stat_clut_last[2],
+        s_dbg_last_raw, (double)s_dbg_last_col[0], (double)s_dbg_last_col[1],
+        (double)s_dbg_last_col[2],
+        s_bld_max_h, s_bld_tall_runs, s_bld_tall_matched,
+        (unsigned long long)s_bld_tall_hash, s_bld_tall_x, s_bld_tall_y,
+        s_stat_decode_fail, s_stat_scale_reject, s_stat_atlas_full,
+        s_stat_missing);
+    if (n >= cap)
+        return 0;
+
+    for (int i = 0; i < s_unres_n; i++) {
+        unsigned k = (unsigned)snprintf(out + n, cap - n,
+            "%s{\"bx\":%d,\"by\":%d,\"d\":%d,\"x0\":%d,\"y0\":%d,"
+            "\"x1\":%d,\"y1\":%d,\"n\":%u}",
+            i ? "," : "", s_unres[i].bx, s_unres[i].by, s_unres[i].depth,
+            s_unres[i].x0, s_unres[i].y0, s_unres[i].x1, s_unres[i].y1,
+            s_unres[i].n);
+        if (k >= cap - n) return 0;
+        n += k;
+    }
+    n += (unsigned)snprintf(out + n, cap - n, "],\"copies\":[");
+    if (n >= cap) return 0;
+    for (int i = 0; i < s_copylog_n; i++) {
+        const int ai = s_copylog[i].asset;
+        unsigned k = (unsigned)snprintf(out + n, cap - n,
+            "%s{\"name\":\"%s\",\"sx\":%d,\"sy\":%d,\"sw\":%d,\"sh\":%d,"
+            "\"dx\":%d,\"dy\":%d,\"n\":%u}",
+            i ? "," : "",
+            (ai >= 0 && ai < s_asset_n) ? s_asset[ai].name : "?",
+            s_copylog[i].sx, s_copylog[i].sy, s_copylog[i].sw, s_copylog[i].sh,
+            s_copylog[i].dx, s_copylog[i].dy, s_copylog[i].n);
+        if (k >= cap - n) return 0;
+        n += k;
+    }
+    n += (unsigned)snprintf(out + n, cap - n, "],\"shapes\":[");
+    if (n >= cap) return 0;
+
+    for (int i = 0; i < s_shape_n; i++) {
+        unsigned k = (unsigned)snprintf(out + n, cap - n,
+            "%s{\"w\":%d,\"h\":%d,\"seen\":%u,\"matched\":%u}",
+            i ? "," : "", s_shape[i].w, s_shape[i].h,
+            s_shape[i].seen, s_shape[i].matched);
+        if (k >= cap - n) return 0;
+        n += k;
+    }
+    n += (unsigned)snprintf(out + n, cap - n, "],\"runlog\":[");
+    if (n >= cap) return 0;
+    for (int i = 0; i < s_runlog_n; i++) {
+        int j = (s_runlog_head - s_runlog_n + i + TP_RUNLOG * 2) % TP_RUNLOG;
+        unsigned k = (unsigned)snprintf(out + n, cap - n,
+            "%s{\"x\":%d,\"y\":%d,\"w\":%d,\"h\":%d,\"m\":%d,\"hash\":\"%016llx\"}",
+            i ? "," : "", s_runlog[j].x, s_runlog[j].y, s_runlog[j].w,
+            s_runlog[j].h, s_runlog[j].matched,
+            (unsigned long long)s_runlog[j].hash);
+        if (k >= cap - n) return 0;
+        n += k;
+    }
+    n += (unsigned)snprintf(out + n, cap - n, "],\"live\":[");
+    if (n >= cap) return 0;
+
+    /* Naming the live regions is what turns "a hash matched" into "the RIGHT
+     * asset matched" -- the check worth having before anything is drawn. */
+    for (int i = 0; i < s_region_n; i++) {
+        const TpRegion *r = &s_region[i];
+        const char *nm = (r->asset >= 0) ? s_asset[r->asset].name : "?";
+        unsigned k = (unsigned)snprintf(
+            out + n, cap - n,
+            "%s{\"name\":\"%s\",\"x\":%d,\"y\":%d,\"w\":%d,\"h\":%d}",
+            i ? "," : "", nm, r->x, r->y, r->w, r->h);
+        if (k >= cap - n)
+            return 0;
+        n += k;
+    }
+    return (unsigned)snprintf(out + n, cap - n, "]") < cap - n;
+}

--- a/src/texture_pack.h
+++ b/src/texture_pack.h
@@ -1,0 +1,467 @@
+/* texture_pack.h -- draw HD art in place of the game's own 2D textures.
+ *
+ * WHAT THIS REPLACES, AND WHY IT IS NOT A DISC PATCH
+ * ---------------------------------------------------
+ * Patching art into the disc image cannot give you HD: the game decompresses
+ * its art into RAM and hands it to the GPU at the original size, so a bigger
+ * picture on the disc is just a bigger picture the game will not read. The
+ * swap has to happen where the art reaches the renderer.
+ *
+ * Every piece of 2D art travels one road to the screen -- a CPU->VRAM transfer,
+ * already decompressed, delivered to the renderer as one bulk rectangle by
+ * gr_vram_transfer_in(). Watching that road catches all of it without knowing
+ * anything about how the disc is laid out.
+ *
+ * NAMES, NOT HASHES
+ * ------------------
+ * An upload is identified by the content hash of its payload, but a hash is a
+ * miserable thing to hand a pack author. So the TITLE registers what its art
+ * is called -- "this hash is cards/042/image" -- and packs are then ordinary
+ * directories of PNGs whose paths mirror those names:
+ *
+ *     <player data>/textures/cards/042/image.png
+ *
+ * That registration is the whole game-specific surface. This file knows
+ * nothing about MRG files, card ids or where a disc keeps its artwork; it is
+ * handed names and hashes and does the rest. A title that registers nothing
+ * still gets a working framework, just one where nothing is ever replaced.
+ *
+ * INTEGER SCALES ONLY
+ * --------------------
+ * A replacement must be a whole multiple of the source's texel size: 102x96
+ * art is replaced at 204x192, 408x384, and so on. Anything else is refused
+ * rather than stretched -- counted in texpack_state_json()'s refusal tally,
+ * since nothing here may print -- because the shader maps a primitive's
+ * uv into the replacement as
+ *
+ *     atlas_texel = atlas_origin + (uv - region_origin) * scale
+ *
+ * and a fractional scale makes that inexact. The error shows up as seams along
+ * sprite edges -- worst precisely where the art is cut into pieces, which on a
+ * PS1 title is everywhere.
+ *
+ * WHAT A PALETTE SWAP DOES TO THIS
+ * ---------------------------------
+ * The console recolours art by swapping CLUTs rather than by storing several
+ * copies, and a flat RGBA replacement cannot do that. So the lookup key is the
+ * texture hash AND the CLUT hash, with a palette-agnostic fallback:
+ *
+ *     <name>.png              any palette -- one picture for every variant
+ *     <name>@<cluthash>.png   this palette only
+ *
+ * The exact form wins when present. A pack that does not care about recolours
+ * ships the plain file and never thinks about it; a pack that does ships one
+ * per palette and keeps the variation.
+ *
+ * BACKENDS
+ * ---------
+ * Tracking and lookup here are backend-independent, but only the OpenGL
+ * backend can currently DRAW a replacement -- it already samples VRAM as an
+ * integer texture and decodes CLUTs in the fragment shader, which is the shape
+ * a replacement path slots into. On Vulkan and software a pack is inert and
+ * the stock art draws.
+ */
+#ifndef TEXTURE_PACK_H
+#define TEXTURE_PACK_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- lifecycle ----------------------------------------------------------- */
+
+/* Set up <player data>/textures, the one pack slot. Safe before the renderer
+ * is up, safe to call twice. */
+void texpack_init(void);
+void texpack_shutdown(void);
+
+/* The renderer's VRAM mirror, so a draw can hash what it samples. Called from
+ * gr_init(); until it is set the framework is inert. */
+void texpack_set_vram(const uint16_t *vram);
+
+/* Look for any registered anchored art in the VRAM mirror and place the
+ * regions that confirm. Cheap once everything has resolved, so calling it
+ * once a frame is the intended use. */
+void texpack_resolve_anchors(void);
+
+/* Ask for the active pack's FILES to be read again -- call after editing art
+ * on disk, or the old decode keeps drawing. Registrations and regions are
+ * untouched; only decoded pictures and the atlas are rebuilt, lazily.
+ *
+ * The request is deferred: texpack_reload_if_pending() performs it, and must
+ * be called once per frame from the same thread that draws. Doing the work
+ * inside a menu callback would free art out from under a draw in progress. */
+void texpack_request_reload(void);
+void texpack_reload_if_pending(void);
+
+/* The palette the game last drew `name` with, read out of the VRAM mirror --
+ * `entries` 16-bit BGR555 words. For art whose CLUT is not stored beside its
+ * pixels, this is the only reliable source of its real colours, and without
+ * it such art can only be exported as a grey index map. Returns 0 if the
+ * asset has not been drawn yet, since nothing has told us the answer. */
+int texpack_observed_clut(const char *name, uint16_t *out, int entries);
+
+/* The same, for one band of a multi-band asset. Art taller than a 256-row
+ * texture page is registered as several bands under one name; `src_y` picks
+ * the band (0, 256, 512, ...). Bands do not share a palette, so exporting a
+ * tall sheet correctly means asking per band. */
+int texpack_observed_clut_page(const char *name, int src_y,
+                               uint16_t *out, int entries);
+
+/* The palettes this art is drawn with, EACH WITH THE REGION IT APPLIES TO.
+ *
+ * A sheet the game recolours has no single correct palette -- the dialogue
+ * frame's border is stone where its fill is navy -- so one palette per asset
+ * cannot describe it and an export through one of them is wrong everywhere
+ * else. These are recorded per drawn rectangle instead, in whole-image texel
+ * coordinates, so an export can colour each part the way the game does.
+ *
+ * Only regions actually drawn are known, so this fills in as screens are
+ * visited. */
+/* Every recorded region palette, as its own debug response -- the main state
+ * JSON has no room for 60 of them and silently truncated to a dozen, which
+ * read as "this asset has none" when it simply was not in the first twelve. */
+int texpack_clut_json(char *out, unsigned cap);
+
+int texpack_clut_rect_count(const char *name);
+/* Where that region was last drawn on screen, so an export can lay the pieces
+ * out as the player sees them. Returns 0 if it has no recorded destination. */
+int texpack_clut_rect_dst(const char *name, int which,
+                          int *x0, int *y0, int *x1, int *y1);
+
+int texpack_clut_rect_get(const char *name, int which,
+                          int *x0, int *y0, int *x1, int *y1,
+                          uint16_t *pal, int entries);
+
+/* Mark art as TINTED, meaning its replacement supplies shape and the game
+ * still supplies colour.
+ *
+ * The console recolours art by swapping CLUTs over one set of pixels, and the
+ * text font is the extreme case: one glyph sheet drawn through a bank of
+ * palettes, which is how dialogue, menu headings and card names differ in
+ * colour at all. A flat RGBA replacement has no palette, so replacing the
+ * font normally would freeze every string in the game to one colour and
+ * silently disable anything that colours text.
+ *
+ * A tinted replacement is multiplied by the colour the CLUT would have given,
+ * so a white glyph on transparency comes out in whatever colour the game
+ * selected -- one file, every colourway preserved. Paint tinted art neutral:
+ * its own colour multiplies in, so white means "exactly the game's colour".
+ * Only 4/8bpp art has a CLUT; tinting a 16bpp asset does nothing. */
+/* Anchor one BAND of an already-registered multi-page asset.
+ *
+ * texpack_register_asset_anchored() makes a standalone image; this attaches an
+ * anchor to a band that is part of a larger one, so the band still maps into
+ * the same file. Needed because a tall asset can have one band that matches as
+ * a whole page and another the game partly overwrites -- the title logo is
+ * both at once. The band's registered extent must equal the anchor rectangle,
+ * or the hash covers different bytes than the rectangle does and never
+ * matches. */
+int texpack_set_anchor(const char *name, int src_y,
+                       int vram_x, int vram_y, int vram_w, int vram_h);
+
+int texpack_set_tinted(const char *name, int on);
+
+/* Record this art's palettes PER DRAWN REGION (see texpack_clut_rect_get).
+ * Opt-in: the pool is shared, and art whose palette the title already knows
+ * would fill it before the art that needs it is ever drawn. */
+int texpack_set_track_cluts(const char *name, int on);
+
+/* Never resolve to the plain "<name>.png" fallback for this asset -- only to
+ * a matching per-draw element or an exact @cluthash file. See the .c for why:
+ * a single flat file cannot describe art the game recolours. */
+int texpack_set_no_plain_fallback(const char *name, int on);
+
+/* ---- what the title registers -------------------------------------------- */
+
+/* "An upload whose payload hashes to `hash` is the art called `name`."
+ *
+ * `name` is a pack-relative path without extension, e.g. "cards/042/image".
+ * w and h are the source's size in TEXELS, which is what an integer scale is
+ * measured against -- not the size of the VRAM rectangle the upload lands on,
+ * since a 4bpp texel is a quarter of a VRAM word.
+ *
+ * Returns 0 if the registry is full. Registering the same hash twice keeps the
+ * first name. */
+int texpack_register_asset(const char *name, uint64_t hash, int w, int h);
+
+/* Register art that the game uploads BEFORE this framework starts watching --
+ * the in-game text font is the case: it is written to VRAM during boot and
+ * never transferred again, so no amount of watching transfers will ever see
+ * it. Instead of a transfer, such an asset names the VRAM rectangle it
+ * occupies (`vram_*`, in 16-bit words and rows) and is looked for there
+ * whenever a whole-VRAM write lands.
+ *
+ * The position only says where to LOOK. The rectangle is still hashed and
+ * compared against `hash`, so if the position or size is wrong the asset
+ * simply does not resolve -- it never binds a name to whatever art happens to
+ * be sitting at those coordinates. `w`,`h` are the texel size as usual. */
+int texpack_register_asset_anchored(const char *name, uint64_t hash,
+                                    int w, int h,
+                                    int vram_x, int vram_y,
+                                    int vram_w, int vram_h);
+
+/* A replacement transform: convert the in_w x in_h RGBA picture the player
+ * painted into the out_w x out_h RGBA the game actually samples. Used for art
+ * the game stores scrambled in VRAM (backgrounds) so the player edits a clean
+ * image and this repacks it. RGBA8, tightly packed, top-down. */
+typedef void (*TexPackRetile)(const uint8_t *in, int in_w, int in_h,
+                              uint8_t *out, int out_w, int out_h);
+
+/* Like texpack_register_asset, but the file on disk is DISPLAY layout
+ * (disp_w x disp_h -- what the scene looks like) while the game samples the
+ * TILED layout (w x h, which the hash covers). A replacement is validated as
+ * an integer multiple of disp_w x disp_h, then `retile` packs it to w x h at
+ * that scale before it enters the atlas. */
+int         texpack_register_asset_tiled(const char *name, uint64_t hash,
+                                         int w, int h, int disp_w, int disp_h,
+                                         TexPackRetile retile);
+
+/* The general form. An asset may be one PAGE of a larger image, because a PS1
+ * texture page is at most 256 rows: anything taller is uploaded as several
+ * pages and must be registered (and matched) per page.
+ *
+ *   w,h            what THIS page is -- the size the game uploads and samples
+ *   disp_w,disp_h  the file on disk, which covers the whole image
+ *   page_w,page_h  the whole image after `retile` (== disp when retile is 0)
+ *   src_x,src_y    where this page sits inside that whole image
+ *
+ * Several pages therefore share one file: the loader applies retile once, then
+ * crops this page out of the result. A pack author still edits one picture. */
+int         texpack_register_asset_page(const char *name, uint64_t hash,
+                                        int w, int h,
+                                        int disp_w, int disp_h,
+                                        int page_w, int page_h,
+                                        int src_x, int src_y,
+                                        TexPackRetile retile);
+
+/* FNV-1a over a buffer, so a title can hash disc bytes with the same function
+ * this hashes uploads with. Both sides MUST agree or nothing ever matches. */
+uint64_t texpack_hash(const void *data, unsigned len);
+
+/* Same idea, widened to 128 bits, for identifying a PALETTE specifically.
+ * A palette is 32-512 bytes of highly structured BGR555 data, and across a
+ * whole session's worth of distinct UI colourings, two genuinely different
+ * palettes were found to collide under plain 64-bit FNV-1a -- a dialogue
+ * border's real palette and an unrelated one exported earlier landed on the
+ * identical digest, so the wrong file was served with full confidence. */
+void texpack_hash128(const void *data, unsigned len, uint64_t out[2]);
+
+/* ---- packs --------------------------------------------------------------- */
+
+int         texpack_pack_count(void);
+const char *texpack_pack_name(int index);
+/* The pack's full directory on disk -- <player-data>/textures, normally --
+ * but a title reading/writing a pack's files (an asset-browsing tool, say)
+ * needs the real path rather than rebuilding that guess itself. NULL out of
+ * range. */
+const char *texpack_pack_path(int index);
+int         texpack_active_pack(void);          /* -1 when none */
+void        texpack_set_active_pack(int index); /* -1 disables replacement */
+/* Point the active pack at an arbitrary absolute folder -- what a "choose a
+ * different folder" control wants, as opposed to texpack_set_active_pack's
+ * index into the packs already found. Reuses the matching pack slot if this
+ * path is already one of them, else claims (or replaces) a synthetic slot for
+ * it, so texpack_active_dir() and everything built on it immediately agree on
+ * exactly this folder. */
+void        texpack_set_active_dir(const char *path);
+
+/* The active pack's own folder -- texpack_pack_path(texpack_active_pack()),
+ * resolved the one place instead of at every caller, and never empty: with
+ * nothing active yet it falls back to <player-data>/textures, the same
+ * folder texpack_init() sets up as the one pack slot, so there is always a
+ * real place to write to. This is the single definition of "the pack folder"
+ * that the raw VRAM injector, the exporter, and any higher-level replacement
+ * that wants to live beside it (card art, CPU portraits) all share -- so two
+ * windows never quietly agree on two different folders. */
+void        texpack_active_dir(char *out, unsigned cap);
+
+/* Player-facing on/off. Distinct from selecting no pack: this leaves the pack
+ * loaded and its atlas populated, so toggling is instant and free -- which is
+ * what you want when comparing replaced art against the original. */
+void        texpack_set_enabled(int on);
+int         texpack_enabled(void);
+
+/* "Is there a replacement ready for this asset right now?" -- 1 only when
+ * replacement is enabled, a pack is active, and that pack actually ships the
+ * file. A title uses this to stand its OWN art-replacement paths down when the
+ * pack already covers an asset, so the two do not fight over the same pixels. */
+int         texpack_has_replacement(const char *name);
+
+/* Bumped only when the active pack's file list is (re)scanned -- activation,
+ * a manual reload, or (once one exists) the pack directory itself changing --
+ * never by ordinary draws or uploads. A title that gates its OWN replacement
+ * path on texpack_has_replacement() at load time (see that function's own
+ * comment) can be asked before the pack has finished its first scan, and a
+ * per-file mtime watch never re-asks once its own file hasn't changed. Poll
+ * this alongside that watch and re-run the query when it changes, so "the
+ * pack only became ready a moment after I first checked" self-corrects
+ * instead of sticking with a stale false forever. */
+unsigned    texpack_file_scan_generation(void);
+
+/* ---- VRAM observation (called by the renderer facade) -------------------- */
+
+/* One completed CPU->VRAM transfer. The rectangle becomes a candidate source
+ * region and anything it overlaps stops being one. x/y/w are in VRAM 16-bit
+ * words, matching gr_vram_transfer_in(). */
+void texpack_on_upload(int x, int y, int w, int h, const uint16_t *data);
+
+/* VRAM changed some other way -- a fill, a VRAM->VRAM copy, a savestate.
+ * Anything the rectangle touches stops being a valid source. */
+void texpack_invalidate_rect(int x, int y, int w, int h);
+void texpack_invalidate_all(void);
+
+/* ---- draw-time lookup ---------------------------------------------------- */
+
+/* Where a primitive should read its replacement, in atlas texels. A
+ * primitive's uv is relative to its texture page while the replacement is
+ * relative to the source region, so the shader needs the region's origin
+ * expressed in this primitive's own texel space to line them up. */
+typedef struct {
+    float atlas_x, atlas_y;   /* the replacement's top-left in the atlas */
+    float org_u, org_v;       /* the source region's origin, in prim texels */
+    float scale;              /* replacement pixels per source texel (>= 1) */
+    /* How the replacement is to be drawn:
+     *   0 FLAT     the file's own RGB. HD colour, but the palette is frozen.
+     *   1 TINTED   the game's CLUT colour, the file's alpha. Correct under
+     *              every palette, but only cutout edges can sharpen.
+     *   2 INDEXED  the file holds INDICES, not colour, and the shader looks
+     *              them up in the game's CLUT per pixel -- what the console
+     *              itself does, just at the replacement's resolution. Sharp
+     *              AND correct under every palette; limited to the palette's
+     *              own colours. */
+    int   mode;
+} TexPackHit;
+
+/* Resolve one textured primitive: 1 and fills `out` when a replacement
+ * applies, 0 when the stock path should draw.
+ *
+ * base_x/base_y are the texture page origin in VRAM words, depth is 0/1/2 for
+ * 4/8/16bpp, clut_x/clut_y locate the palette, and lim is the inclusive
+ * sampled uv bound {lo_u, lo_v, hi_u, hi_v} from psx_uv_tri_limits(). Results
+ * are cached, so calling this per primitive is cheap after the first draw of
+ * each distinct asset. */
+/* `dst` is the primitive's SCREEN bounding box {x0,y0,x1,y1}, or NULL. It is
+ * not used for resolving -- it is recorded, so an export can reassemble a
+ * sheet the way the screen shows it instead of the way VRAM stores it. */
+int texpack_on_draw(int base_x, int base_y, int depth,
+                    int clut_x, int clut_y, const int lim[4],
+                    const int dst[4], TexPackHit *out);
+
+/* A VRAM-to-VRAM copy (GP0(80h)) never goes through texpack_on_draw -- it
+ * moves raw words, not a textured primitive, so it has no depth/clut/uv to
+ * report and nothing here would notice it happened. That is a real blind
+ * spot: an asset whose content the game COPIES to a different address
+ * before actually drawing it from there is invisible to every mechanism in
+ * this file, anchored or not -- the anchor still matches because the source
+ * bytes sit untouched, but no primitive ever samples that address directly,
+ * which looks identical to "genuinely never drawn" from texpack_on_draw's
+ * side. ui/menu_labels_1 is the confirmed case this exists for: LIVE at its
+ * anchor, zero real draws there across two isolated sessions.
+ *
+ * Called from gpu_copy_rect() with the raw GP0(80h) rectangle in VRAM words,
+ * both endpoints. Records it (in a small ring, see the debug server's
+ * "copies" list) only when the SOURCE overlaps a currently registered
+ * region, so this stays cheap on every frame's unrelated copies and only
+ * ever holds copies that might explain why a specific asset never resolves. */
+void texpack_note_copy(int sx, int sy, int w, int h, int dx, int dy);
+
+/* ---- unknown-asset capture -------------------------------------------------
+ *
+ * A discovery aid, separate from replacement. texpack_on_draw's "no region
+ * claims this primitive" case currently just counts it (see the debug
+ * server's "unres" list) -- everything past that point (which disc bytes
+ * this is, what colour it really draws in) has to be reconstructed by hand:
+ * take a savestate, pull VRAM, hash-match it against a disc dump, guess a
+ * bit depth, guess a palette, look, guess again. Every one of those steps is
+ * information texpack_on_draw ALREADY HAS at the moment it decides "no match"
+ * -- the exact VRAM rectangle, the exact live CLUT -- and is about to throw
+ * away. This keeps it instead: decode the rectangle through its own live
+ * palette, right there, and queue it for a game layer to save. No disc
+ * offset, no hash-matching, no guessing; the picture comes from what was
+ * actually on screen, in the colour it was actually shown in. */
+void texpack_set_capture_enabled(int on);
+int  texpack_capture_enabled(void);
+
+typedef struct {
+    int base_x, base_y, depth, clut_x, clut_y;  /* same meaning as texpack_on_draw */
+    int lim[4];
+    int dst[4];             /* screen bbox, or all zero if draw passed NULL */
+    int w, h;                /* the captured rectangle, in texels */
+    const uint8_t *rgba;     /* w*h*4; BORROWED -- valid for the process's
+                             * life, do not free. Kept here (not handed off)
+                             * because a game layer needs to see the WHOLE
+                             * accumulated pile repeatedly to group pieces
+                             * that sit next to each other on screen (one
+                             * panel's worth of icons, one logo's worth of
+                             * bands), the same way write_screens() already
+                             * groups a known asset's recorded regions --
+                             * a one-shot consume-once queue cannot do that,
+                             * since the piece that completes a group might
+                             * not arrive until several frames after the
+                             * first one in it. */
+
+    /* The SAME rectangle, word-aligned and in the SAME shape
+     * rescan_anchored() reads and hashes for an anchor check: anch_w/anch_h
+     * VRAM words starting at anch_x/anch_y, raw (not palette-decoded), row-
+     * major. A game layer that saves this alongside the picture can hash it
+     * with texpack_hash() and hand the result straight to
+     * texpack_register_asset_anchored() -- a real, permanently re-matchable
+     * catalog entry, with NO disc offset ever needed, because the hash this
+     * produces is bit-for-bit what rescan_anchored() will compute the next
+     * time this exact content is on screen. Without this, a hash computed
+     * from the decoded RGBA (or from lim[], which is texel-granular and not
+     * necessarily word-aligned) would not match anything real -- it would
+     * just be a number that happens to describe a picture nobody ever
+     * re-derives the same way twice. */
+    int anch_x, anch_y, anch_w, anch_h;
+    const uint16_t *raw;     /* anch_w*anch_h words; BORROWED, do not free */
+} TexPackCapture;
+
+/* How many distinct captures exist so far this session. Grows as new (rect,
+ * palette) combinations are seen; never shrinks except when the fixed pool
+ * (TP_CAP_ALL in texture_pack.c) is full, at which point capture silently
+ * stops accepting new ones rather than evicting what a game layer may already
+ * be part-way through grouping -- same "keep what is already recorded"
+ * choice s_clutrect's own pool-full case makes. */
+int texpack_capture_count(void);
+
+/* Read capture `i` (0-indexed, stable for the life of the process). 1 on
+ * success, 0 if `i` is out of range. */
+int texpack_capture_get(int i, TexPackCapture *out);
+
+/* ---- atlas (for the drawing backend) ------------------------------------- */
+
+int texpack_atlas_dim(void);   /* side of the square RGBA8 atlas, in pixels */
+
+
+/* ---- diagnostics ---------------------------------------------------------- */
+
+/* Debug-server state line, in this title's usual shape. Carries the counts and
+ * -- the useful part -- why replacements were refused, since a pack that
+ * silently does nothing is the normal failure and stdout is not available to
+ * explain it (psxrecomp/CLAUDE.md rule 3). */
+int texpack_state_json(char *out, unsigned cap);
+
+/* Diagnostic only: record the raw flag / vertex colour of a primitive that is
+ * about to be (or was) HD-replaced, so texpack_state_json can report what the
+ * game's own GPU command actually carried. Called from the renderer, which
+ * already has both as ordinary GPU state. */
+void texpack_debug_note_prim(int rawtex, const float col[3]);
+
+/* Per-VRAM-page hashes and what they resolve to, for locating art the game
+ * draws from but nothing has registered. */
+int texpack_vram_pages_json(char *out, unsigned cap);
+
+/* Hand the backend the next replacement still needing upload into its atlas
+ * texture, as tightly packed RGBA8. 0 when nothing is pending. Call in a loop
+ * before drawing. */
+int texpack_take_pending(int *x, int *y, int *w, int *h, const uint8_t **rgba);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEXTURE_PACK_H */


### PR DESCRIPTION
Adds the render-pipeline hooks the HD texture-pack / Asset Manager feature (companion PR: Unchiga/YuGiOhForbiddenMemoriesRecomp#<fill in>) needs to actually draw a replacement texture in the real game, instead of only in tool-window previews. The matching/atlas-packing engine itself (texture_pack.c/.h) lives in the superproject now, not in this submodule — this PR is only the minimal, narrow hook points inside the existing render path that let it do its job. Based on community-fixes-2026-09-10 (a0786f1b).

What changed

runtime/src/gpu_render.c — the renderer facade. Three one-line forwards into the texture-pack engine, at the points where the game's own VRAM state actually changes:

gr_init calls texpack_set_vram() so the engine has a pointer to guest VRAM.
gr_fill_rect / gr_copy_rect call texpack_invalidate_rect() first — a fill or a VRAM→VRAM copy overwrites art a replacement was tracking, so it has to be told before the write happens or it can end up painting stale art onto a rectangle the game has since reused.
gr_vram_transfer_in calls texpack_on_upload() — the one path essentially all 2D art (UI, cards, backgrounds) travels through on its way from disc to VRAM, and the only place a replacement can be matched against what's being uploaded.

runtime/src/gpu_gl_renderer.c — the actual substitution, GL-side:

New uniforms on the textured-triangle shader (u_atlas, u_repl, u_replorg, u_atlasdim) and a leading branch in the fragment shader: when a primitive has an active replacement, sample the shared HD atlas texture instead of raw VRAM (three sub-modes — flat RGBA, tinted/luminance, and indexed-CLUT — matching texture_pack.h's three replacement modes).
ensure_atlas() / pump_atlas_uploads(): lazily creates the atlas GL texture and drains the engine's pending-upload queue (texpack_take_pending()) each time the textured batch flushes.
gpu_textured_triangle() — the single function all four textured-draw entry points (glb_draw_textured_triangle, glb_draw_shaded_textured_triangle, and both textured-rect variants via gpu_textured_rect()) already funnel through — now calls texpack_on_draw() per primitive and folds replacement identity into the existing batch-flush key, so a replacement change flushes the batch the same way a semi-transparency/mask/filter/texture-window change already does.
Atlas bilinear-bleeding fix: the shared replacement atlas uses GL_LINEAR filtering, and sampling near a packed cell's edge let the GPU's bilinear tap read into whatever's packed in the next cell — visible as thin seams between tiles of a multi-primitive image (caught live on the Konami boot screen, a grid of separately-drawn tiles). Fixed by clamping the atlas-space sample coordinate to stay half a texel inside the primitive's own cell, derived from its existing v_limits × the replacement's scale factor — no atlas repacking or padding needed.

runtime/src/psx_ui_draw.c — psx_ui_blit_scaled()'s color-accumulation loop was folding RGB but silently treating source alpha as always opaque; fixed to fold alpha into per-pixel coverage like the other three channels, so a replacement with real transparency composites correctly instead of always drawing fully opaque.